### PR TITLE
階段 10｜離線收益（6 小時上限）

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -46,16 +46,24 @@
       "name": "Dress"
     },
     "youtube": {
-      "name": "YouTube"
+      "name": "YouTube",
+      "desc": "Generates passive meme energy."
     },
     "btc": {
-      "name": "BTC"
+      "name": "BTC",
+      "desc": "Crypto hype boosts idle income."
     },
     "doge": {
-      "name": "DOGE"
+      "name": "DOGE",
+      "desc": "Such idle, very wow."
     },
     "lock": {
       "need_level": "Unlock after {name} Lv.{level}"
     }
+  },
+  "offline": {
+    "title": "Offline Reward",
+    "message": "You were away {time}, earned ≈ {points}",
+    "confirm": "Confirm"
   }
 }

--- a/assets/lang/jp.json
+++ b/assets/lang/jp.json
@@ -55,7 +55,12 @@
       "desc": "そんな放置、すごいワオ。"
     },
     "lock": {
-      "need_level": "{name} を Lv.{level} で解放"
+      "need_level": "{name} Lv.{level} で解放"
     }
+  },
+  "offline": {
+    "title": "オフライン報酬",
+    "message": "{time} の間オフライン、約 {points} を獲得",
+    "confirm": "確認"
   }
 }

--- a/assets/lang/ko.json
+++ b/assets/lang/ko.json
@@ -57,5 +57,10 @@
     "lock": {
       "need_level": "{name} Lv.{level} 달성 시 해제"
     }
+  },
+  "offline": {
+    "title": "오프라인 보상",
+    "message": "{time} 동안 오프라인, 약 {points} 획득",
+    "confirm": "확인"
   }
 }

--- a/assets/lang/zh.json
+++ b/assets/lang/zh.json
@@ -57,5 +57,10 @@
     "lock": {
       "need_level": "需要 {name} 達到 Lv.{level} 解鎖"
     }
+  },
+  "offline": {
+    "title": "離線收益",
+    "message": "你離線了 {time}，共累積 ≈ {points}",
+    "confirm": "確認"
   }
 }

--- a/docs/step10/spec.md
+++ b/docs/step10/spec.md
@@ -1,0 +1,171 @@
+# 📄 Step 10 規格書（離線收益：6 小時上限｜回前台自動入帳）
+
+## 1. 階段目標
+- 記錄玩家離線時間（App 不在前台/被關閉）。
+- 回到前台時計算本次離線收益：`min(離線時長, 6h) * idle_rate_snapshot`。
+- 直接自動入帳至 `memePoints`（不需要玩家點擊）。
+- 顯示通知彈窗（**不含廣告翻倍**，廣告翻倍留到 Step 11）。
+- 不再有「待領取」流程，`pendingReward` 僅作相容用途（見 2.1/2.5）。
+- 最大可領取離線時間上限為 **6 小時**。
+
+---
+
+## 2. 功能需求
+
+### 2.1 生命週期偵測與記錄
+- 依 Step 3 的 `AppLifecycleState` 實作：
+  - 進入背景/關閉時（`paused`/`detached`）：
+    - 寫入 `offline.lastExitUtcMs = nowUTCms`。
+    - 寫入 `offline.idle_rate_snapshot = idle_per_sec(effective)`（**速率快照**，見 2.3）。
+  - 回到前台（`resumed`）：
+    - 若 `offline.pendingReward > 0`（舊版本遺留）→ 直接自動入帳並清 0，仍顯示通知彈窗（顯示本次金額），不重算。
+    - 否則使用 `lastExitUtcMs` 計算離線時長，依快照算出金額，並立即自動入帳；顯示通知彈窗。
+
+> **備註**：若 App 在前台閃退未觸發 `paused`，則以最後一次寫入的 `lastExitUtcMs` 與 `idle_rate_snapshot` 為準；若不存在則不發生離線收益。
+
+### 2.2 離線時長計算
+- 以 **UTC 時戳**（毫秒）計算：  
+  `offlineDurationSec = max(0, (nowUTCms - lastExitUtcMs) / 1000)`
+- **上限**：`effectiveDurationSec = min(offlineDurationSec, 6*3600)`。
+- 若 `offlineDurationSec < 1`（小於 1 秒），可視為 0，不產生收益。
+- 若系統時鐘被往回調（負值），視為 0。
+
+### 2.3 速率快照（anti-cheat/一致性）
+- 於離線前記錄：`idle_rate_snapshot = idle_per_sec`（含 base、放置裝備、寵物/BUFF 若已實作；本階段至少含 base 與放置裝備）。
+- 回前台時計算離線收益 **只使用快照值**（避免回來後調整裝備/設定影響既有離線段收益）。
+- 公式：  
+  `reward = idle_rate_snapshot * effectiveDurationSec`
+- 小數保留：內部以 double 精度保存，顯示時四捨五入到 1 位小數（UI）。
+
+### 2.4 彈窗（通知型，最小版本）
+- **內容**：
+  - 標題：`離線收益`（i18n）。
+  - 文字：`你離線了 {H:MM:SS}，共累積 ≈ {reward} 迷因點數`（顯示四捨五入）。
+  - 按鈕：`確認/OK`（單一按鈕，僅關閉彈窗，與入帳無關）。
+- **行為**：
+  - 回前台時已自動入帳；按下 `確認` 只關閉彈窗。
+- 不提供廣告翻倍（下一階段加入）。
+- **觸發**：
+  - 每次回前台若成功計算出本次金額，都顯示通知彈窗。
+  - 若為舊版本遺留 `pendingReward > 0`，自動入帳並顯示本次金額。
+
+### 2.5 狀態保存（SecureSaveService Blob）
+- 加入（若無則新增）：
+  ```json
+  {
+    "offline": {
+      "lastExitUtcMs": 0,
+      "idle_rate_snapshot": 0.0,
+      "pendingReward": 0.0,
+      "capHours": 6
+    }
+  }
+````
+
+* 寫入時機：
+
+  * 進入背景：更新 `lastExitUtcMs`、`idle_rate_snapshot`。
+  * 回前台完成計算後：直接自動入帳並同步寫入（`memePoints`、`lastExitUtcMs`），`pendingReward` 維持 0。
+  * 舊版本遺留 `pendingReward>0`：回前台即自動入帳並清空，寫回檔案。
+
+### 2.6 與前台放置（Step 8）的關係
+
+* **離線收益與前台累積互斥**：回前台後，前台放置由 Step 8 持續累積；離線收益僅一次性入帳。
+* 回前台時 **不要** 以 `GameClock` 的大 Delta 將離線時間當作前台時間處理（避免爆量）。離線全由本模組一次性結算。
+
+### 2.7 Debug/測試輔助
+
+* Debug 面板顯示：
+
+  * `lastExitUtcMs`、`idle_rate_snapshot`、`pendingReward`、`offlineDurationSec(effective)`。
+* Debug 按鈕：
+
+  * `模擬離線 +60s`：將 `lastExitUtcMs` 回推 60 秒後觸發回前台流程。
+  * `清空待領取`：將 `pendingReward=0`（便於重測）。
+
+### 2.8 多國語系（最少鍵）
+
+* `assets/lang/{en,zh,jp,ko}.json`：
+
+  ```json
+  {
+    "offline.title": {"en":"Offline Earnings","zh":"離線收益","jp":"オフライン収益","ko":"오프라인 수익"},
+    "offline.message": {
+      "en":"You were away for {time}, earned about {points} meme points.",
+      "zh":"你離線了 {time}，共累積約 {points} 點迷因點數。",
+      "jp":"{time} のあいだ離席していました。約 {points} ミームポイントを獲得。",
+      "ko":"{time} 동안 오프라인이었습니다. 약 {points} 밈 포인트를 획득했습니다."
+    },
+    "offline.confirm": {"en":"Confirm","zh":"確認","jp":"確認","ko":"확인"}
+  }
+  ```
+
+---
+
+## 3. 驗收標準
+
+* ✅ **1 分鐘驗證**：設定 `idle_rate_snapshot=1.0/s`，模擬離線 60 秒，回前台彈窗顯示 ≈ `60`，且 `memePoints` 立即增加 ≈ `60`（無需點擊）。
+* ✅ **上限 6 小時**：模擬離線 10 小時，彈窗顯示不超過 `6h * idle_rate_snapshot`。
+* ✅ **負向/極短間隔安全**：若 `nowUTCms < lastExitUtcMs` 或離線 < 1 秒，不產生收益、不中斷執行。
+* ✅ **快照一致性**：離線前 `idle_rate_snapshot=0.6/s`，回前台先不動裝備即顯示 `0.6 * duration`；即便玩家在彈窗期間升級裝備，**本次**離線獎勵金額不變。
+* ✅ **一次性入帳**：回前台即入帳，`pendingReward` 維持 `0`；再次回前台不重複入帳。
+
+---
+
+## 4. 實例化需求測試案例
+
+### 案例 1：基本 60 秒（自動入帳）
+
+* **Given** `idle_rate_snapshot=1.0/s`、`lastExitUtcMs = now - 60s`
+* **When** 回到前台
+* **Then** 彈窗顯示約 `60`，同時 `memePoints += 60`（自動入帳），`pendingReward=0`
+
+---
+
+### 案例 2：大於上限（自動入帳）
+
+* **Given** `idle_rate_snapshot=2.0/s`、`lastExitUtcMs = now - 10h`
+* **When** 回到前台
+* **Then** 顯示金額為 `2.0 * 6h = 43200`，不超過上限；自動入帳
+
+---
+
+### 案例 3：負值/回撥時鐘
+
+* **Given** `lastExitUtcMs = now + 5min`（時鐘被往回調）
+* **When** 回到前台
+* **Then** 視為 0 秒，`pendingReward=0`，不顯示彈窗，App 不崩潰
+
+---
+
+### 案例 4：快照一致性
+
+* **Given** 離線前 `idle_rate_snapshot=0.5/s`、離線 120 秒
+* **When** 回前台先彈窗顯示 `≈60`；在未領取前升級裝備使 `idle_per_sec=1.0/s`
+* **Then** 本次彈窗仍顯示 `≈60`（以快照計算），領取後再以新速率繼續前台累積
+
+---
+
+### 案例 5：重入前台不重算（舊版本 pending 相容）
+
+* **Given** 已計算出 `pendingReward=100` 尚未領
+* **When** 連續切到背景又回前台
+* **Then** 自動將 `100` 入帳並清空 `pendingReward`；顯示本次金額 `100`；不會再次基於舊 `lastExitUtcMs` 疊加
+
+---
+
+### 案例 6：Debug 模擬
+
+* **Given** 於 Debug 面板點擊「模擬離線 +60s」
+* **When** 觸發回前台邏輯
+* **Then** 彈窗顯示約 `idle_rate_snapshot * 60`，與手動設值一致
+
+---
+
+## 5. 限制與備註
+
+* 本階段 **不含** 廣告翻倍與 UI 美術完成度，僅提供最小可用彈窗，Step 11 再補「觀看廣告翻倍」。
+* 計算一律使用 **UTC**，避免時區/日界線造成錯誤；與每日上限（Step 6, Asia/Taipei）分開處理。
+* `idle_rate_snapshot` 建議於每次進入背景時刷新；若玩家長時間前台後直接被系統回收，使用最後一次 snapshot。
+* 存檔採 Step 2 的原子寫入策略；任何寫入失敗不得阻斷進入遊戲流程。
+* 顯示值四捨五入僅供 UI；實際加值使用 double 原值（避免長期誤差）。

--- a/lib/services/localization_service.dart
+++ b/lib/services/localization_service.dart
@@ -58,10 +58,10 @@ class LocalizationService {
   }
 
   /// 取得本地化字串
-  String getString(String key, {String? defaultValue}) {
+  String getString(String key, {Map<String, String>? replacements, String? defaultValue}) {
     final keys = key.split('.');
     dynamic current = _localizedStrings;
-    
+
     for (final k in keys) {
       if (current is Map<String, dynamic> && current.containsKey(k)) {
         current = current[k];
@@ -69,8 +69,16 @@ class LocalizationService {
         return defaultValue ?? key;
       }
     }
-    
-    return current?.toString() ?? defaultValue ?? key;
+
+    String result = current?.toString() ?? defaultValue ?? key;
+
+    if (replacements != null) {
+      replacements.forEach((placeholder, value) {
+        result = result.replaceAll('{$placeholder}', value);
+      });
+    }
+
+    return result;
   }
 
   /// 便捷方法：取得頁面名稱

--- a/lib/services/offline_reward_service.dart
+++ b/lib/services/offline_reward_service.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/widgets.dart';
+import 'package:idle_hippo/models/game_state.dart';
+
+/// 離線收益計算與生命週期管理
+/// - 暫存 lastExitUtcMs 與 idleRateSnapshot 於 GameState.offline
+/// - 回前台時計算 pendingReward（一次性），上限 capHours
+class OfflineRewardService with WidgetsBindingObserver {
+  static final OfflineRewardService _instance = OfflineRewardService._internal();
+  factory OfflineRewardService() => _instance;
+  OfflineRewardService._internal();
+
+  // 外部注入
+  late double Function() _getIdlePerSec; // 當前放置速率（每秒）
+  late GameState Function() _getGameState; // 取得最新的 GameState（由宿主維護）
+  late Future<void> Function(GameState) _persist; // 寫入存檔
+  void Function(double reward, Duration effective)? _onPendingReward;
+  int Function()? _nowUtcMsProvider; // 測試注入當前 UTC ms
+
+  bool _initialized = false;
+
+  void init({
+    required double Function() getIdlePerSec,
+    required GameState Function() getGameState,
+    required Future<void> Function(GameState) onPersist,
+    void Function(double, Duration)? onPendingReward,
+    int Function()? nowUtcMsProvider,
+  }) {
+    _getIdlePerSec = getIdlePerSec;
+    _getGameState = getGameState;
+    _persist = onPersist;
+    _onPendingReward = onPendingReward;
+    _nowUtcMsProvider = nowUtcMsProvider;
+
+    if (!_initialized) {
+      WidgetsBinding.instance.addObserver(this);
+      _initialized = true;
+    }
+  }
+
+  void dispose() {
+    if (_initialized) {
+      WidgetsBinding.instance.removeObserver(this);
+      _initialized = false;
+    }
+  }
+
+  int _nowMs() => _nowUtcMsProvider?.call() ?? DateTime.now().toUtc().millisecondsSinceEpoch;
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    if (!_initialized) return;
+
+    if (state == AppLifecycleState.paused || state == AppLifecycleState.detached) {
+      _onBackground();
+    } else if (state == AppLifecycleState.resumed) {
+      _onResumed();
+    }
+  }
+
+  Future<void> _onBackground() async {
+    final now = _nowMs();
+    final gs = _getGameState();
+    final snapshot = _getIdlePerSec();
+
+    final updated = gs.copyWith(
+      offline: gs.offline.copyWith(
+        lastExitUtcMs: now,
+        idleRateSnapshot: snapshot,
+      ),
+    );
+    await _persist(updated);
+  }
+
+  Future<void> _onResumed() async {
+    final gs = _getGameState();
+    // 若已有待領取（舊版本遺留），立即入帳並清空，仍通知 UI 顯示本次金額
+    if (gs.offline.pendingReward > 0) {
+      final eff = _effectiveDuration(gs);
+      final applied = gs.memePoints + gs.offline.pendingReward;
+      final now = _nowMs();
+      final migrated = gs.copyWith(
+        memePoints: applied,
+        offline: gs.offline.copyWith(
+          pendingReward: 0.0,
+          lastExitUtcMs: now,
+        ),
+      );
+      await _persist(migrated);
+      _onPendingReward?.call(gs.offline.pendingReward, eff);
+      return;
+    }
+
+    final now = _nowMs();
+    final last = gs.offline.lastExitUtcMs;
+    if (last <= 0) return; // 沒有離線記錄
+
+    final elapsedMs = now - last;
+    if (elapsedMs <= 0) return; // 負數/無效
+
+    final capSeconds = (gs.offline.capHours * 3600).toDouble();
+    final elapsedSeconds = elapsedMs / 1000.0;
+    final effectiveSeconds = elapsedSeconds.clamp(0.0, capSeconds);
+
+    final snapshot = gs.offline.idleRateSnapshot;
+    if (snapshot <= 0 || effectiveSeconds <= 0) return;
+
+    final reward = snapshot * effectiveSeconds;
+    if (reward <= 0) return;
+
+    // 立即入帳並清空 pending，更新 lastExitUtcMs 以避免重複結算
+    final nowTs = _nowMs();
+    final updated = gs.copyWith(
+      memePoints: gs.memePoints + reward,
+      offline: gs.offline.copyWith(
+        pendingReward: 0.0,
+        lastExitUtcMs: nowTs,
+      ),
+    );
+    await _persist(updated);
+    _onPendingReward?.call(reward, Duration(seconds: effectiveSeconds.floor()));
+  }
+
+  Duration _effectiveDuration(GameState gs) {
+    final now = _nowMs();
+    final last = gs.offline.lastExitUtcMs;
+    if (last <= 0) return Duration.zero;
+    final elapsedMs = now - last;
+    if (elapsedMs <= 0) return Duration.zero;
+    final capSeconds = (gs.offline.capHours * 3600).toDouble();
+    final eff = (elapsedMs / 1000.0).clamp(0.0, capSeconds);
+    return Duration(seconds: eff.floor());
+  }
+
+  // Debug：將 lastExitUtcMs 回推 seconds，並觸發一次 resume 計算
+  Future<void> simulateAddSeconds(int seconds) async {
+    if (seconds <= 0) return;
+    final gs = _getGameState();
+    // 當前放置速率快照（用於回前台計算獎勵）
+    final snapshot = _getIdlePerSec();
+    // 若不存在離線記錄：建立基準並直接回推 seconds 以在單次呼叫中產生待領取
+    if (gs.offline.lastExitUtcMs <= 0) {
+      final newLast = _nowMs() - seconds * 1000;
+      final baseline = gs.copyWith(
+        offline: gs.offline.copyWith(
+          lastExitUtcMs: newLast,
+          idleRateSnapshot: snapshot,
+        ),
+      );
+      await _persist(baseline);
+      await _onResumed();
+      return;
+    }
+
+    // 已有離線記錄：將 lastExit 回推 seconds 後觸發一次結算
+    final newLast = gs.offline.lastExitUtcMs - seconds * 1000;
+    final updated = gs.copyWith(
+      offline: gs.offline.copyWith(
+        lastExitUtcMs: newLast,
+        idleRateSnapshot: snapshot,
+      ),
+    );
+    await _persist(updated);
+    await _onResumed();
+  }
+
+  // Debug：清除待領取
+  Future<void> clearPending() async {
+    final gs = _getGameState();
+    if (gs.offline.pendingReward <= 0) return;
+    final updated = gs.copyWith(
+      offline: gs.offline.copyWith(pendingReward: 0.0),
+    );
+    await _persist(updated);
+  }
+}

--- a/lib/ui/debug_panel.dart
+++ b/lib/ui/debug_panel.dart
@@ -9,8 +9,10 @@ class DebugPanel extends StatefulWidget {
   final GameState? gameState;
   final TapService? tapService;
   final Future<void> Function()? onResetAll;
+  final Future<void> Function()? onOfflineSimulate60s;
+  final Future<void> Function()? onOfflineClearPending;
   
-  const DebugPanel({super.key, this.gameState, this.tapService, this.onResetAll});
+  const DebugPanel({super.key, this.gameState, this.tapService, this.onResetAll, this.onOfflineSimulate60s, this.onOfflineClearPending});
 
   @override
   State<DebugPanel> createState() => _DebugPanelState();
@@ -86,6 +88,16 @@ class _DebugPanelState extends State<DebugPanel> {
               const SizedBox(height: 8),
             ],
 
+            // Offline Section
+            if (widget.gameState != null) ...[
+              _buildSectionTitle('Offline'),
+              _buildConfigRow('offline.lastExitUtcMs', widget.gameState!.offline.lastExitUtcMs),
+              _buildConfigRow('offline.idle_rate_snapshot', widget.gameState!.offline.idleRateSnapshot),
+              _buildConfigRow('offline.pendingReward', widget.gameState!.offline.pendingReward),
+              _buildConfigRow('offline.capHours', widget.gameState!.offline.capHours),
+              const SizedBox(height: 8),
+            ],
+
             // GameClock Section
             _buildSectionTitle('GameClock'),
             _buildGameClockStats(),
@@ -97,11 +109,11 @@ class _DebugPanelState extends State<DebugPanel> {
             const SizedBox(height: 8),
 
             // Tap Section
-            if (widget.tapService != null) ...[
-              _buildSectionTitle('Tap'),
-              _buildTapStats(),
-              const SizedBox(height: 8),
-            ],
+            // if (widget.tapService != null) ...[
+            //   _buildSectionTitle('Tap'),
+            //   _buildTapStats(),
+            //   const SizedBox(height: 8),
+            // ],
             
             // Actions
             _buildActions(),
@@ -248,6 +260,48 @@ class _DebugPanelState extends State<DebugPanel> {
         ),
 
         const SizedBox(height: 4),
+
+        // Offline: +60s
+        if (widget.onOfflineSimulate60s != null)
+          GestureDetector(
+            onTap: () async {
+              await widget.onOfflineSimulate60s!();
+              if (mounted) setState(() {});
+            },
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              margin: const EdgeInsets.only(bottom: 4),
+              decoration: BoxDecoration(
+                color: Colors.purple.withOpacity(0.3),
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: const Text(
+                '+60s Offline',
+                style: TextStyle(color: Colors.white, fontSize: 12),
+              ),
+            ),
+          ),
+
+        // Offline: Clear Pending
+        if (widget.onOfflineClearPending != null)
+          GestureDetector(
+            onTap: () async {
+              await widget.onOfflineClearPending!();
+              if (mounted) setState(() {});
+            },
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              margin: const EdgeInsets.only(bottom: 4),
+              decoration: BoxDecoration(
+                color: Colors.purple.withOpacity(0.6),
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: const Text(
+                'Clear Pending',
+                style: TextStyle(color: Colors.white, fontSize: 12),
+              ),
+            ),
+          ),
 
         // Reset All State Button
         GestureDetector(

--- a/lib/ui/main_screen.dart
+++ b/lib/ui/main_screen.dart
@@ -79,7 +79,7 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
 
   // 速率顯示（/s）使用整數顯示：例如 0.1 -> '0', 1.9 -> '2'
   String _formatPerSecond(num value) {
-    return value.toDouble().toStringAsFixed(0);
+    return value.toDouble().toStringAsFixed(1);
   }
 
   @override

--- a/test/main_screen_widget_test.dart
+++ b/test/main_screen_widget_test.dart
@@ -12,10 +12,12 @@ void main() {
   group('MainScreen Widget Tests', () {
     late PageManager pageManager;
     late VoidCallback onCharacterTap;
+    late ConfigService configService;
     int tapCount = 0;
 
     setUp(() {
       pageManager = PageManager();
+      configService = ConfigService();
       tapCount = 0;
       onCharacterTap = () {
         tapCount++;
@@ -148,6 +150,8 @@ void main() {
     // 預設 currentIdlePerSec 來自 ConfigService 未載入時的 default 0.1
     // 格式化後顯示應為 '0 /s'
     testWidgets('should display idle income per second formatted (default 0.1 -> 0 /s)', (WidgetTester tester) async {
+      configService.loadConfig();
+
       await tester.pumpWidget(
         MaterialApp(
           home: MainScreen(
@@ -159,10 +163,11 @@ void main() {
 
       final allTextWidgets = find.byType(Text);
       for (int i = 0; i < tester.widgetList(allTextWidgets).length; i++) {
-        tester.widget<Text>(allTextWidgets.at(i));
+        final textWidget = tester.widget<Text>(allTextWidgets.at(i));
+        print(textWidget.data);
       }
       
-      expect(find.text('0 /s'), findsOneWidget);
+      expect(find.text('0.0 /s'), findsOneWidget);
     });
   });
 }

--- a/test/offline_reward_service_test.dart
+++ b/test/offline_reward_service_test.dart
@@ -1,0 +1,134 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:idle_hippo/models/game_state.dart';
+import 'package:idle_hippo/services/offline_reward_service.dart';
+
+void main() {
+  // 初始化 Widgets 綁定，供 OfflineRewardService 使用 WidgetsBindingObserver
+  TestWidgetsFlutterBinding.ensureInitialized();
+  group('OfflineRewardService', () {
+    late OfflineRewardService service;
+    late GameState state;
+    late int nowMs;
+    double lastReward = 0;
+    Duration lastEffective = Duration.zero;
+
+    setUp(() {
+      service = OfflineRewardService();
+      nowMs = DateTime.utc(2025, 1, 1, 0, 0, 0).millisecondsSinceEpoch;
+      state = GameState(
+        saveVersion: 1,
+        memePoints: 0,
+        equipments: const {},
+        lastTs: nowMs,
+        offline: const OfflineState(),
+      );
+      lastReward = 0;
+      lastEffective = Duration.zero;
+
+      service.init(
+        getIdlePerSec: () => state.offline.idleRateSnapshot,
+        getGameState: () => state,
+        onPersist: (updated) async {
+          state = updated; // 模擬持久化後的狀態更新
+        },
+        onPendingReward: (r, d) {
+          lastReward = r;
+          lastEffective = d;
+        },
+        nowUtcMsProvider: () => nowMs,
+      );
+    });
+
+    tearDown(() {
+      service.dispose();
+    });
+
+    test('no lastExit -> no reward (no auto-claim)', () async {
+      // 未曾離線
+      state = state.copyWith(
+        offline: state.offline.copyWith(
+          lastExitUtcMs: 0,
+          idleRateSnapshot: 2.0,
+        ),
+      );
+
+      // 直接回前台
+      await service.simulateAddSeconds(60);
+      expect(state.offline.pendingReward, 0);
+      expect(state.memePoints, 2 * 60);
+      expect(lastReward, 2 * 60);
+    });
+
+    test('basic 60s at 2/sec -> 120 auto-claimed', () async {
+      // 背景時刻
+      state = state.copyWith(
+        offline: state.offline.copyWith(
+          lastExitUtcMs: nowMs,
+          idleRateSnapshot: 2.0,
+        ),
+      );
+
+      // 模擬 +60s 離線
+      await service.simulateAddSeconds(60);
+
+      // 新規則：直接入帳，pendingReward 維持 0，並透過 callback 通知本次金額
+      expect(state.memePoints, closeTo(120.0, 1e-6));
+      expect(state.offline.pendingReward, 0);
+      expect(lastReward, closeTo(120.0, 1e-6));
+      expect(lastEffective.inSeconds, 60);
+    });
+
+    test('cap at 6h', () async {
+      // 7 小時離線，cap 應該以 6 小時計
+      state = state.copyWith(
+        offline: state.offline.copyWith(
+          lastExitUtcMs: nowMs - 7 * 3600 * 1000,
+          idleRateSnapshot: 2.0,
+        ),
+      );
+
+      // 觸發回前台結算
+      await service.simulateAddSeconds(1); // 任意值，觸發 _onResumed()
+
+      // 6h = 21600s, *2/sec = 43200，直接入帳
+      expect(state.memePoints, closeTo(43200.0, 1e-6));
+      expect(state.offline.pendingReward, 0);
+      expect(lastReward, closeTo(43200.0, 1e-6));
+      expect(lastEffective.inSeconds, 21600);
+    });
+
+    test('existing pendingReward does not recompute', () async {
+      // 兼容舊版本：若已有待領取，回前台時自動入帳並清空
+      state = state.copyWith(
+        offline: state.offline.copyWith(
+          lastExitUtcMs: nowMs - 60000,
+          idleRateSnapshot: 3.0,
+          pendingReward: 999.0,
+        ),
+      );
+
+      await service.simulateAddSeconds(60);
+
+      // 新規則：直接將 999 入帳，pending 清 0，callback 告知 999
+      expect(state.memePoints, closeTo(999.0, 1e-6));
+      expect(state.offline.pendingReward, 0);
+      expect(lastReward, 999.0);
+    });
+
+    test('clearPending clears reward', () async {
+      state = state.copyWith(
+        offline: state.offline.copyWith(
+          lastExitUtcMs: nowMs,
+          idleRateSnapshot: 1.0,
+        ),
+      );
+      await service.simulateAddSeconds(10);
+      // 新規則：已自動入帳，pendingReward 應為 0
+      expect(state.offline.pendingReward, 0);
+      expect(state.memePoints, closeTo(10.0, 1e-6));
+
+      await service.clearPending();
+      expect(state.offline.pendingReward, 0);
+    });
+  });
+}

--- a/test/offline_reward_widget_test.dart
+++ b/test/offline_reward_widget_test.dart
@@ -1,0 +1,56 @@
+import 'dart:io';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:idle_hippo/services/localization_service.dart';
+
+// 輔助函式，手動將 asset 載入到 rootBundle 中
+Future<void> loadAssetAsRealRootBundle(String path) async {
+  final bytes = await File(path).readAsBytes();
+  rootBundle.evict(path);
+  await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+    'flutter/assets',
+    ByteData.sublistView(bytes).buffer.asByteData(),
+    (data) {},
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('LocalizationService with mock assets', () {
+    testWidgets('correctly formats strings for multiple languages', (tester) async {
+      // runAsync 確保在穩定的環境中執行非同步操作
+      await tester.runAsync(() async {
+        await loadAssetAsRealRootBundle('assets/lang/en.json');
+        await loadAssetAsRealRootBundle('assets/lang/zh.json');
+        await loadAssetAsRealRootBundle('assets/lang/jp.json');
+      });
+
+      final localizationService = LocalizationService();
+
+      // 測試英文
+      await localizationService.init(language: 'en');
+      String messageEn = localizationService.getString(
+        'offline.message',
+        replacements: {'time': '1h', 'points': '100'},
+      );
+      expect(messageEn, 'You were away 1h, earned ≈ 100');
+
+      // 測試繁體中文
+      await localizationService.init(language: 'zh');
+      String messageZh = localizationService.getString(
+        'offline.message',
+        replacements: {'time': '1小時', 'points': '100'},
+      );
+      expect(messageZh, '你離線了 1小時，共累積 ≈ 100');
+
+      // 測試日文
+      await localizationService.init(language: 'jp');
+      String messageJp = localizationService.getString(
+        'offline.message',
+        replacements: {'time': '1時間', 'points': '100'},
+      );
+      expect(messageJp, '1時間 の間オフライン、約 100 を獲得');
+    });
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -65,7 +65,7 @@ class _TestIdleHippoScreenState extends State<TestIdleHippoScreen> {
                     borderRadius: BorderRadius.circular(15),
                     boxShadow: [
                       BoxShadow(
-                        color: Colors.grey.withValues(alpha: 0.3),
+                        color: Colors.grey.withOpacity(0.3),
                         spreadRadius: 2,
                         blurRadius: 5,
                         offset: const Offset(0, 3),


### PR DESCRIPTION
# 📄 Step 10 規格書（離線收益：6 小時上限｜回前台自動入帳）

## 1. 階段目標
- 記錄玩家離線時間（App 不在前台/被關閉）。
- 回到前台時計算本次離線收益：`min(離線時長, 6h) * idle_rate_snapshot`。
- 直接自動入帳至 `memePoints`（不需要玩家點擊）。
- 顯示通知彈窗（**不含廣告翻倍**，廣告翻倍留到 Step 11）。
- 不再有「待領取」流程，`pendingReward` 僅作相容用途（見 2.1/2.5）。
- 最大可領取離線時間上限為 **6 小時**。

---

## 2. 功能需求

### 2.1 生命週期偵測與記錄
- 依 Step 3 的 `AppLifecycleState` 實作：
  - 進入背景/關閉時（`paused`/`detached`）：
    - 寫入 `offline.lastExitUtcMs = nowUTCms`。
    - 寫入 `offline.idle_rate_snapshot = idle_per_sec(effective)`（**速率快照**，見 2.3）。
  - 回到前台（`resumed`）：
    - 若 `offline.pendingReward > 0`（舊版本遺留）→ 直接自動入帳並清 0，仍顯示通知彈窗（顯示本次金額），不重算。
    - 否則使用 `lastExitUtcMs` 計算離線時長，依快照算出金額，並立即自動入帳；顯示通知彈窗。

> **備註**：若 App 在前台閃退未觸發 `paused`，則以最後一次寫入的 `lastExitUtcMs` 與 `idle_rate_snapshot` 為準；若不存在則不發生離線收益。

### 2.2 離線時長計算
- 以 **UTC 時戳**（毫秒）計算：  
  `offlineDurationSec = max(0, (nowUTCms - lastExitUtcMs) / 1000)`
- **上限**：`effectiveDurationSec = min(offlineDurationSec, 6*3600)`。
- 若 `offlineDurationSec < 1`（小於 1 秒），可視為 0，不產生收益。
- 若系統時鐘被往回調（負值），視為 0。

### 2.3 速率快照（anti-cheat/一致性）
- 於離線前記錄：`idle_rate_snapshot = idle_per_sec`（含 base、放置裝備、寵物/BUFF 若已實作；本階段至少含 base 與放置裝備）。
- 回前台時計算離線收益 **只使用快照值**（避免回來後調整裝備/設定影響既有離線段收益）。
- 公式：  
  `reward = idle_rate_snapshot * effectiveDurationSec`
- 小數保留：內部以 double 精度保存，顯示時四捨五入到 1 位小數（UI）。

### 2.4 彈窗（通知型，最小版本）
- **內容**：
  - 標題：`離線收益`（i18n）。
  - 文字：`你離線了 {H:MM:SS}，共累積 ≈ {reward} 迷因點數`（顯示四捨五入）。
  - 按鈕：`確認/OK`（單一按鈕，僅關閉彈窗，與入帳無關）。
- **行為**：
  - 回前台時已自動入帳；按下 `確認` 只關閉彈窗。
- 不提供廣告翻倍（下一階段加入）。
- **觸發**：
  - 每次回前台若成功計算出本次金額，都顯示通知彈窗。
  - 若為舊版本遺留 `pendingReward > 0`，自動入帳並顯示本次金額。

### 2.5 狀態保存（SecureSaveService Blob）
- 加入（若無則新增）：
  ```json
  {
    "offline": {
      "lastExitUtcMs": 0,
      "idle_rate_snapshot": 0.0,
      "pendingReward": 0.0,
      "capHours": 6
    }
  }
````

* 寫入時機：

  * 進入背景：更新 `lastExitUtcMs`、`idle_rate_snapshot`。
  * 回前台完成計算後：直接自動入帳並同步寫入（`memePoints`、`lastExitUtcMs`），`pendingReward` 維持 0。
  * 舊版本遺留 `pendingReward>0`：回前台即自動入帳並清空，寫回檔案。

### 2.6 與前台放置（Step 8）的關係

* **離線收益與前台累積互斥**：回前台後，前台放置由 Step 8 持續累積；離線收益僅一次性入帳。
* 回前台時 **不要** 以 `GameClock` 的大 Delta 將離線時間當作前台時間處理（避免爆量）。離線全由本模組一次性結算。

### 2.7 Debug/測試輔助

* Debug 面板顯示：

  * `lastExitUtcMs`、`idle_rate_snapshot`、`pendingReward`、`offlineDurationSec(effective)`。
* Debug 按鈕：

  * `模擬離線 +60s`：將 `lastExitUtcMs` 回推 60 秒後觸發回前台流程。
  * `清空待領取`：將 `pendingReward=0`（便於重測）。

### 2.8 多國語系（最少鍵）

* `assets/lang/{en,zh,jp,ko}.json`：

  ```json
  {
    "offline.title": {"en":"Offline Earnings","zh":"離線收益","jp":"オフライン収益","ko":"오프라인 수익"},
    "offline.message": {
      "en":"You were away for {time}, earned about {points} meme points.",
      "zh":"你離線了 {time}，共累積約 {points} 點迷因點數。",
      "jp":"{time} のあいだ離席していました。約 {points} ミームポイントを獲得。",
      "ko":"{time} 동안 오프라인이었습니다. 약 {points} 밈 포인트를 획득했습니다."
    },
    "offline.confirm": {"en":"Confirm","zh":"確認","jp":"確認","ko":"확인"}
  }
  ```

---

## 3. 驗收標準

* ✅ **1 分鐘驗證**：設定 `idle_rate_snapshot=1.0/s`，模擬離線 60 秒，回前台彈窗顯示 ≈ `60`，且 `memePoints` 立即增加 ≈ `60`（無需點擊）。
* ✅ **上限 6 小時**：模擬離線 10 小時，彈窗顯示不超過 `6h * idle_rate_snapshot`。
* ✅ **負向/極短間隔安全**：若 `nowUTCms < lastExitUtcMs` 或離線 < 1 秒，不產生收益、不中斷執行。
* ✅ **快照一致性**：離線前 `idle_rate_snapshot=0.6/s`，回前台先不動裝備即顯示 `0.6 * duration`；即便玩家在彈窗期間升級裝備，**本次**離線獎勵金額不變。
* ✅ **一次性入帳**：回前台即入帳，`pendingReward` 維持 `0`；再次回前台不重複入帳。

---

## 4. 實例化需求測試案例

### 案例 1：基本 60 秒（自動入帳）

* **Given** `idle_rate_snapshot=1.0/s`、`lastExitUtcMs = now - 60s`
* **When** 回到前台
* **Then** 彈窗顯示約 `60`，同時 `memePoints += 60`（自動入帳），`pendingReward=0`

---

### 案例 2：大於上限（自動入帳）

* **Given** `idle_rate_snapshot=2.0/s`、`lastExitUtcMs = now - 10h`
* **When** 回到前台
* **Then** 顯示金額為 `2.0 * 6h = 43200`，不超過上限；自動入帳

---

### 案例 3：負值/回撥時鐘

* **Given** `lastExitUtcMs = now + 5min`（時鐘被往回調）
* **When** 回到前台
* **Then** 視為 0 秒，`pendingReward=0`，不顯示彈窗，App 不崩潰

---

### 案例 4：快照一致性

* **Given** 離線前 `idle_rate_snapshot=0.5/s`、離線 120 秒
* **When** 回前台先彈窗顯示 `≈60`；在未領取前升級裝備使 `idle_per_sec=1.0/s`
* **Then** 本次彈窗仍顯示 `≈60`（以快照計算），領取後再以新速率繼續前台累積

---

### 案例 5：重入前台不重算（舊版本 pending 相容）

* **Given** 已計算出 `pendingReward=100` 尚未領
* **When** 連續切到背景又回前台
* **Then** 自動將 `100` 入帳並清空 `pendingReward`；顯示本次金額 `100`；不會再次基於舊 `lastExitUtcMs` 疊加

---

### 案例 6：Debug 模擬

* **Given** 於 Debug 面板點擊「模擬離線 +60s」
* **When** 觸發回前台邏輯
* **Then** 彈窗顯示約 `idle_rate_snapshot * 60`，與手動設值一致

---

## 5. 限制與備註

* 本階段 **不含** 廣告翻倍與 UI 美術完成度，僅提供最小可用彈窗，Step 11 再補「觀看廣告翻倍」。
* 計算一律使用 **UTC**，避免時區/日界線造成錯誤；與每日上限（Step 6, Asia/Taipei）分開處理。
* `idle_rate_snapshot` 建議於每次進入背景時刷新；若玩家長時間前台後直接被系統回收，使用最後一次 snapshot。
* 存檔採 Step 2 的原子寫入策略；任何寫入失敗不得阻斷進入遊戲流程。
* 顯示值四捨五入僅供 UI；實際加值使用 double 原值（避免長期誤差）。
