### PR TITLE
階段 27-3｜權益發放 & 冪等

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "chatgpt.openOnStartup": false
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@
 ## Config Document
 - **docs/**：可額外存放 PM spec、遊戲設計圖
 - 每次實作需求前都需要查看 assets/config 內參數，是否新需求有可以共用的，那就不需要再新增而外變數
-- 每當有新增新增數於 assets/config 內，則需要更新 docs/config.md 文件
+- 每當在 assets/config 內新增數值，則需要更新 docs/config.md 文件
 
 ## Other Flutter Guidelines
 - withOpacity 都改用 withValues 方法

--- a/assets/config/store_effects.json
+++ b/assets/config/store_effects.json
@@ -1,0 +1,138 @@
+{
+  "store.card_click_perm": {
+    "type": "permanent",
+    "effects": {
+      "clickBoost": 1.5
+    },
+    "description": "點擊加成 +50%"
+  },
+  "store.card_idle_perm": {
+    "type": "permanent",
+    "effects": {
+      "idleBoost": 1.2
+    },
+    "description": "Idle 加成 +20%"
+  },
+  "store.card_click_2x_30m": {
+    "type": "timed",
+    "effects": {
+      "click_2x": {
+        "multiplier": 2.0,
+        "durationMinutes": 30
+      }
+    },
+    "description": "點擊倍數 2x，持續 30 分鐘"
+  },
+  "store.card_idle_2x_1h": {
+    "type": "timed",
+    "effects": {
+      "idle_2x": {
+        "multiplier": 2.0,
+        "durationMinutes": 60
+      }
+    },
+    "description": "Idle 倍數 2x，持續 1 小時"
+  },
+  "store.card_offline_perm_6h": {
+    "type": "permanent",
+    "effects": {
+      "offlineExtended": true
+    },
+    "description": "離線獎勵永久 +6 小時"
+  },
+  "store.card_offline_once_6h": {
+    "type": "timed",
+    "effects": {
+      "offline_extended": {
+        "multiplier": 1.0,
+        "durationMinutes": 1440
+      }
+    },
+    "description": "離線獎勵暫時 +6 小時，持續 24 小時"
+  },
+  "store.card_cap_perm": {
+    "type": "permanent",
+    "effects": {
+      "capIncreased": true
+    },
+    "description": "每日上限 +50%"
+  },
+  "store.ticket_pet_single": {
+    "type": "instant",
+    "effects": {
+      "petTickets": 1
+    },
+    "description": "寵物抽獎券 +1"
+  },
+  "store.ticket_pet_10plus1": {
+    "type": "instant",
+    "effects": {
+      "petTickets": 11
+    },
+    "description": "寵物抽獎券 +11"
+  },
+  "store.pack_daily": {
+    "type": "bundle",
+    "effects": {
+      "instant": {
+        "memePoints": 300,
+        "petTickets": 2
+      },
+      "timed": {
+        "idle_2x": {
+          "multiplier": 2.0,
+          "durationMinutes": 30
+        }
+      }
+    },
+    "description": "每日禮包：迷因點數 +300、抽獎券 +2、Idle 2x (30分鐘)"
+  },
+  "store.pack_monthly": {
+    "type": "bundle",
+    "effects": {
+      "instant": {
+        "memePoints": 3000,
+        "petTickets": 22
+      },
+      "timed": {
+        "idle_2x": {
+          "multiplier": 2.0,
+          "durationMinutes": 1440
+        }
+      }
+    },
+    "description": "每月禮包：迷因點數 +3000、抽獎券 +22、Idle 2x (24小時)"
+  },
+  "store.pack_7n_starter": {
+    "type": "bundle",
+    "effects": {
+      "instant": {
+        "memePoints": 1000,
+        "petTickets": 11
+      },
+      "timed": {
+        "idle_2x": {
+          "multiplier": 2.0,
+          "durationMinutes": 1440
+        }
+      }
+    },
+    "description": "新手 7 日禮包：迷因點數 +1000、抽獎券 +11、Idle 2x (24小時)"
+  },
+  "store.pack_30n_starter": {
+    "type": "bundle",
+    "effects": {
+      "instant": {
+        "memePoints": 5000,
+        "petTickets": 33
+      },
+      "timed": {
+        "idle_2x": {
+          "multiplier": 2.0,
+          "durationMinutes": 7200
+        }
+      }
+    },
+    "description": "新手 30 日禮包：迷因點數 +5000、抽獎券 +33、Idle 2x (120小時)"
+  }
+}

--- a/docs/step27-3/spec.md
+++ b/docs/step27-3/spec.md
@@ -7,6 +7,7 @@
 * non-consumable：設永久旗標
 * consumable：加資源 & 記錄交易
 * 任一交易 **同一 `orderId`/`purchaseToken` 只處理一次**
+* 實現目前 store.json 中所有商品的購買後效益
 
 ### 規格
 
@@ -28,15 +29,101 @@
     }
   }
   ```
+* 實現目前 store.json 中所有商品的購買後效益
+  * 下面每個商品效益或是數字要參數化，且互相獨立
+* `store.card_click_perm`：購買成功時，每次點擊或獲得迷因點數額外 +50%
+* `store.card_idle_perm`：購買成功時，idlePerSec 累積額外 +20%
+* `store.card_click_2x_30m`：購買成功時，點擊收益乘以 2，並開始 30 分鐘倒數（重複購買延長 30 分鐘）
+* `store.card_idle_2x_1h`：購買成功時，idlePerSec 乘以 2，並開始 1 小時倒數（重複購買延長 1 小時）
+* `store.card_offline_perm_6h`：購買成功時，離線獎勵永久 +6 小時（由 6h → 12h）
+* `store.card_offline_once_6h`：購買成功時，離線獎勵暫時 +6 小時，並開始 24 小時倒數（重複購買延長 24 小時）
+* `store.card_cap_perm`：購買成功時，每日點擊上限永久 +50%（200 → 300）
+* `store.ticket_pet_single`：購買成功時，寵物抽獎券 +1
+* `store.ticket_pet_10plus1`：購買成功時，寵物抽獎券 +11
+* `store.pack_daily`：立即獲得迷因點數 +300、寵物抽獎券 +2，並啟動 idle 2x（30 分鐘，重複購買延長 30 分鐘）
+* `store.pack_monthly`：立即獲得迷因點數 +3000、寵物抽獎券 +22，並啟動 idle 2x（24 小時，重複購買延長 24 小時）
+* `store.pack_7n_starter`：立即獲得迷因點數 +1000、寵物抽獎券 +11，並啟動 idle 2x（24 小時）
+* `store.pack_30n_starter`：立即獲得迷因點數 +5000、寵物抽獎券 +33，並啟動 idle 2x（120 小時）
+
 
 ## 驗收實例化需求
 
 1. **non-consumable 冪等**
-   * Given：連續兩次 `grant(skuId='card_click_perm', orderId='A')`
+   * Given：連續兩次 `grant(skuId='store.card_click_perm', orderId='A')`
    * Then：只會寫入一次 `entitlements.card_click_perm=true`（不重複觸發副作用）
 2. **consumable 冪等**
-   * Given：`grant(skuId='card_click_2x_30m', orderId='B')` 呼叫兩次
+   * Given：`grant(skuId='store.card_click_2x_30m', orderId='B')` 呼叫兩次
    * Then：資源僅被加一次，`orders.B` 僅一筆
 3. **缺 orderId（恢復 non-consumable）**
-   * Given：`grant(skuId='card_idle_perm', orderId=null)`
+   * Given：`grant(skuId='store.card_idle_perm', orderId=null)`
    * Then：仍能設置 entitlement 並具備冪等（重複呼叫不再觸發）
+4. **store.card_click_perm：點擊加成 50%**
+   * Given：原本點擊一次獲得 10 點迷因
+   * When：`grant(skuId='store.card_click_perm')`
+   * Then：點擊一次應獲得 `10 * 1.5 = 15 點`
+5. **store.card_idle_perm：Idle 加成 20%**
+   * Given：原本 idle 每秒 +5 點迷因
+   * When：`grant(skuId='store.card_idle_perm')`
+   * Then：idle 每秒應獲得 `5 * 1.2 = 6 點`
+6. **store.card_click_2x_30m：點擊加倍限時 30 分鐘**
+   * Given：原本點擊一次獲得 10 點迷因
+   * When：`grant(skuId='store.card_click_2x_30m')`
+   * Then：點擊一次應獲得 `10 * 2 = 20 點`，並建立一個 30 分鐘的倒數計時
+   * When：再次購買
+   * Then：倒數時間延長為 60 分鐘
+7. **store.card_idle_2x_1h：Idle 加倍限時 1 小時**
+   * Given：原本 idle 每秒 +5 點迷因
+   * When：`grant(skuId='store.card_idle_2x_1h')`
+   * Then：idle 每秒應獲得 `5 * 2 = 10 點`，並建立一個 1 小時的倒數計時
+   * When：再次購買
+   * Then：倒數時間延長為 2 小時
+8. **store.card_offline_perm_6h：離線獎勵永久 +6 小時**
+   * Given：原本離線可領取時間上限 = 6 小時
+   * When：`grant(skuId='store.card_offline_perm_6h')`
+   * Then：離線時間上限應為 `12 小時`
+9. **store.card_offline_once_6h：離線獎勵暫時 +6 小時（24h 倒數）**
+   * Given：原本離線時間上限 = 6 小時
+   * When：`grant(skuId='store.card_offline_once_6h')`
+   * Then：離線時間上限應為 `12 小時`，並建立一個 24 小時的倒數計時
+   * When：再次購買
+   * Then：倒數時間延長為 48 小時
+10. **store.card_cap_perm：每日上限永久 +50%**
+    * Given：原本每日上限 = 200 點
+   * When：`grant(skuId='store.card_cap_perm')`
+    * Then：每日上限應為 `200 * 1.5 = 300 點`
+11. **store.ticket_pet_single：寵物抽獎券 +1**
+    * Given：原本抽獎券數量 = 0
+   * When：`grant(skuId='store.ticket_pet_single')`
+    * Then：抽獎券數量 = 1
+12. **store.ticket_pet_10plus1：寵物抽獎券 +11**
+    * Given：原本抽獎券數量 = 0
+   * When：`grant(skuId='store.ticket_pet_10plus1')`
+    * Then：抽獎券數量 = 11
+13. **store.pack_daily：每日禮包**
+    * When：`grant(skuId='store.pack_daily')`
+    * Then：
+      * 迷因點數立即增加 300
+      * 抽獎券數量 +2
+      * idle 每秒累積翻倍（2x），並建立 30 分鐘倒數
+    * When：再次購買
+    * Then：倒數時間延長為 60 分鐘
+14. **store.pack_monthly：每月禮包**
+    * When：`grant(skuId='store.pack_monthly')`
+    * Then：
+      * 迷因點數立即增加 3000
+      * 抽獎券數量 +22
+      * idle 每秒累積翻倍（2x），並建立 24 小時倒數
+    * When：再次購買
+    * Then：倒數時間延長為 48 小時
+15. **store.pack_7n_starter：新手 7 日禮包**
+    * When：`grant(skuId='store.pack_7n_starter')`
+    * Then：
+      * 迷因點數立即增加 1000
+      * 抽獎券數量 +11
+      * idle 每秒累積翻倍（2x），並建立 24 小時倒數
+16. **store.pack_30n_starter：新手 30 日禮包**
+    * When：`grant(skuId='store.pack_30n_starter')`
+    * Then：
+      * 迷因點數立即增加 5000
+      * 抽獎券數量 +33
+      * idle 每秒累積翻倍（2x），並建立 120 小時倒數

--- a/docs/step27-3/spec.md
+++ b/docs/step27-3/spec.md
@@ -1,0 +1,42 @@
+# 階段 27-3｜權益發放 & 冪等
+
+## 目標
+
+集中管理「發獎」與「冪等處理」。
+
+* non-consumable：設永久旗標
+* consumable：加資源 & 記錄交易
+* 任一交易 **同一 `orderId`/`purchaseToken` 只處理一次**
+
+### 規格
+
+* 新增 `EntitlementManager`（純前端、本地持久化）
+  * `Future<void> grant({required String skuId, String? orderId})`
+  * `bool hasGrantedOrder(String orderId)`
+  * non-consumable 永久旗標：`entitlement_$skuId = true`
+  * consumable：**加資源**（呼叫你現有的加值 API，如：加票、加 buff 時間），再記錄 `orderId → granted`
+  * 若 `orderId` 為 `null`（Mock 恢復、或非 Android 平台），以 `skuId` 為冪等鍵（僅 non-consumable 可接受）
+* 交易日誌（本地存檔）結構（示意）
+  ```json
+  {
+    "orders": {
+      "GPA.XXXX": { "skuId": "card_click_2x_30m", "grantedAt": 1737xxxx }
+    },
+    "entitlements": {
+      "card_click_perm": true,
+      "card_idle_perm": true
+    }
+  }
+  ```
+
+## 驗收實例化需求
+
+1. **non-consumable 冪等**
+   * Given：連續兩次 `grant(skuId='card_click_perm', orderId='A')`
+   * Then：只會寫入一次 `entitlements.card_click_perm=true`（不重複觸發副作用）
+2. **consumable 冪等**
+   * Given：`grant(skuId='card_click_2x_30m', orderId='B')` 呼叫兩次
+   * Then：資源僅被加一次，`orders.B` 僅一筆
+3. **缺 orderId（恢復 non-consumable）**
+   * Given：`grant(skuId='card_idle_perm', orderId=null)`
+   * Then：仍能設置 entitlement 並具備冪等（重複呼叫不再觸發）

--- a/lib/models/buff_models.dart
+++ b/lib/models/buff_models.dart
@@ -1,0 +1,322 @@
+
+/// 限時 buff 狀態
+class TimedBuff {
+  final String type; // 'click_2x', 'idle_2x', 'offline_6h'
+  final double multiplier; // 倍數或加成值
+  final int expiresAtMs; // UTC 毫秒時間戳
+
+  const TimedBuff({
+    required this.type,
+    required this.multiplier,
+    required this.expiresAtMs,
+  });
+
+  factory TimedBuff.fromMap(Map<String, dynamic> map) {
+    return TimedBuff(
+      type: map['type'] as String,
+      multiplier: (map['multiplier'] as num).toDouble(),
+      expiresAtMs: (map['expiresAtMs'] as num).toInt(),
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+    'type': type,
+    'multiplier': multiplier,
+    'expiresAtMs': expiresAtMs,
+  };
+
+  /// 檢查 buff 是否已過期
+  bool isExpired(int currentTimeMs) {
+    return currentTimeMs >= expiresAtMs;
+  }
+
+  /// 獲取剩餘時間（毫秒）
+  int getRemainingMs(int currentTimeMs) {
+    final remaining = expiresAtMs - currentTimeMs;
+    return remaining > 0 ? remaining : 0;
+  }
+
+  TimedBuff copyWith({
+    String? type,
+    double? multiplier,
+    int? expiresAtMs,
+  }) {
+    return TimedBuff(
+      type: type ?? this.type,
+      multiplier: multiplier ?? this.multiplier,
+      expiresAtMs: expiresAtMs ?? this.expiresAtMs,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is TimedBuff &&
+        other.type == type &&
+        other.multiplier == multiplier &&
+        other.expiresAtMs == expiresAtMs;
+  }
+
+  @override
+  int get hashCode {
+    return type.hashCode ^ multiplier.hashCode ^ expiresAtMs.hashCode;
+  }
+
+  @override
+  String toString() {
+    return 'TimedBuff(type: $type, multiplier: $multiplier, expiresAtMs: $expiresAtMs)';
+  }
+}
+
+/// 永久權益狀態
+class PermanentEntitlements {
+  final double clickBoost; // card_click_perm: 1.5 = +50%
+  final double idleBoost; // card_idle_perm: 1.2 = +20%
+  final bool offlineExtended; // card_offline_perm_6h: +6h
+  final bool capIncreased; // card_cap_perm: +50%
+
+  const PermanentEntitlements({
+    this.clickBoost = 1.0,
+    this.idleBoost = 1.0,
+    this.offlineExtended = false,
+    this.capIncreased = false,
+  });
+
+  factory PermanentEntitlements.fromMap(Map<String, dynamic> map) {
+    return PermanentEntitlements(
+      clickBoost: (map['clickBoost'] ?? 1.0) is num ? (map['clickBoost'] ?? 1.0).toDouble() : 1.0,
+      idleBoost: (map['idleBoost'] ?? 1.0) is num ? (map['idleBoost'] ?? 1.0).toDouble() : 1.0,
+      offlineExtended: (map['offlineExtended'] ?? false) as bool,
+      capIncreased: (map['capIncreased'] ?? false) as bool,
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+    'clickBoost': clickBoost,
+    'idleBoost': idleBoost,
+    'offlineExtended': offlineExtended,
+    'capIncreased': capIncreased,
+  };
+
+  PermanentEntitlements copyWith({
+    double? clickBoost,
+    double? idleBoost,
+    bool? offlineExtended,
+    bool? capIncreased,
+  }) {
+    return PermanentEntitlements(
+      clickBoost: clickBoost ?? this.clickBoost,
+      idleBoost: idleBoost ?? this.idleBoost,
+      offlineExtended: offlineExtended ?? this.offlineExtended,
+      capIncreased: capIncreased ?? this.capIncreased,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is PermanentEntitlements &&
+        other.clickBoost == clickBoost &&
+        other.idleBoost == idleBoost &&
+        other.offlineExtended == offlineExtended &&
+        other.capIncreased == capIncreased;
+  }
+
+  @override
+  int get hashCode {
+    return clickBoost.hashCode ^
+        idleBoost.hashCode ^
+        offlineExtended.hashCode ^
+        capIncreased.hashCode;
+  }
+
+  @override
+  String toString() {
+    return 'PermanentEntitlements(clickBoost: $clickBoost, idleBoost: $idleBoost, '
+        'offlineExtended: $offlineExtended, capIncreased: $capIncreased)';
+  }
+}
+
+/// Buff 系統狀態
+class BuffState {
+  final List<TimedBuff> activeBuffs;
+  final PermanentEntitlements permanent;
+
+  const BuffState({
+    this.activeBuffs = const [],
+    this.permanent = const PermanentEntitlements(),
+  });
+
+  factory BuffState.fromMap(Map<String, dynamic> map) {
+    return BuffState(
+      activeBuffs: map.containsKey('activeBuffs') && map['activeBuffs'] is List
+          ? List<Map<String, dynamic>>.from(map['activeBuffs'] as List)
+              .map(TimedBuff.fromMap)
+              .toList()
+          : const [],
+      permanent: map.containsKey('permanent') && map['permanent'] is Map<String, dynamic>
+          ? PermanentEntitlements.fromMap(map['permanent'] as Map<String, dynamic>)
+          : const PermanentEntitlements(),
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+    'activeBuffs': activeBuffs.map((buff) => buff.toMap()).toList(),
+    'permanent': permanent.toMap(),
+  };
+
+  /// 清理過期的 buff
+  BuffState cleanExpiredBuffs(int currentTimeMs) {
+    final validBuffs = activeBuffs
+        .where((buff) => !buff.isExpired(currentTimeMs))
+        .toList();
+    
+    return copyWith(activeBuffs: validBuffs);
+  }
+
+  /// 添加或延長限時 buff
+  BuffState addOrExtendBuff({
+    required String type,
+    required double multiplier,
+    required int durationMs,
+    required int currentTimeMs,
+  }) {
+    final newBuffs = List<TimedBuff>.from(activeBuffs);
+    
+    // 查找相同類型的現有 buff
+    final existingIndex = newBuffs.indexWhere((buff) => buff.type == type);
+    
+    if (existingIndex != -1) {
+      // 延長現有 buff 的時間
+      final existing = newBuffs[existingIndex];
+      final newExpiresAt = existing.expiresAtMs + durationMs;
+      newBuffs[existingIndex] = existing.copyWith(expiresAtMs: newExpiresAt);
+    } else {
+      // 添加新的 buff
+      final newBuff = TimedBuff(
+        type: type,
+        multiplier: multiplier,
+        expiresAtMs: currentTimeMs + durationMs,
+      );
+      newBuffs.add(newBuff);
+    }
+    
+    return copyWith(activeBuffs: newBuffs);
+  }
+
+  /// 清理過期的 buff
+  BuffState cleanupExpired(int currentTimeMs) {
+    final validBuffs = activeBuffs.where((buff) => !buff.isExpired(currentTimeMs)).toList();
+    
+    if (validBuffs.length == activeBuffs.length) {
+      return this; // 沒有過期的 buff，返回原狀態
+    }
+    
+    return copyWith(activeBuffs: validBuffs);
+  }
+
+  /// 獲取點擊倍數
+  double getClickMultiplier(int currentTimeMs) {
+    double multiplier = 1.0;
+    
+    // 永久加成（使用配置的倍數）
+    if (permanent.clickBoost > 1.0) {
+      multiplier *= permanent.clickBoost;
+    }
+    
+    // 限時加成
+    for (final buff in activeBuffs) {
+      if (buff.type == 'click_2x' && !buff.isExpired(currentTimeMs)) {
+        multiplier *= buff.multiplier;
+      }
+    }
+    
+    return multiplier;
+  }
+
+  /// 獲取 idle 倍數
+  double getIdleMultiplier(int currentTimeMs) {
+    double multiplier = 1.0;
+    
+    // 永久加成（使用配置的倍數）
+    if (permanent.idleBoost > 1.0) {
+      multiplier *= permanent.idleBoost;
+    }
+    
+    // 限時加成
+    for (final buff in activeBuffs) {
+      if (buff.type == 'idle_2x' && !buff.isExpired(currentTimeMs)) {
+        multiplier *= buff.multiplier;
+      }
+    }
+    
+    return multiplier;
+  }
+
+  /// 獲取離線時間上限（小時）
+  int getOfflineCapHours(int currentTimeMs) {
+    int baseHours = 6;
+    
+    // 永久加成
+    if (permanent.offlineExtended) {
+      baseHours += 6; // +6 小時
+    }
+    
+    // 限時加成
+    for (final buff in activeBuffs) {
+      if (buff.type == 'offline_6h' && !buff.isExpired(currentTimeMs)) {
+        baseHours += buff.multiplier.toInt();
+      }
+    }
+    
+    return baseHours;
+  }
+
+  /// 獲取每日點擊上限倍數
+  double getDailyCapMultiplier() {
+    double multiplier = 1.0;
+    
+    // 永久加成
+    if (permanent.capIncreased) {
+      multiplier *= 1.5; // +50%
+    }
+    
+    return multiplier;
+  }
+
+  BuffState copyWith({
+    List<TimedBuff>? activeBuffs,
+    PermanentEntitlements? permanent,
+  }) {
+    return BuffState(
+      activeBuffs: activeBuffs ?? List<TimedBuff>.from(this.activeBuffs),
+      permanent: permanent ?? this.permanent,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is BuffState &&
+        _listEquals(other.activeBuffs, activeBuffs) &&
+        other.permanent == permanent;
+  }
+
+  @override
+  int get hashCode {
+    return activeBuffs.hashCode ^ permanent.hashCode;
+  }
+
+  @override
+  String toString() {
+    return 'BuffState(activeBuffs: ${activeBuffs.length}, permanent: $permanent)';
+  }
+
+  static bool _listEquals(List<TimedBuff> a, List<TimedBuff> b) {
+    if (a.length != b.length) return false;
+    for (int i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
+  }
+}

--- a/lib/models/entitlement_models.dart
+++ b/lib/models/entitlement_models.dart
@@ -1,0 +1,114 @@
+/// 交易日誌模型
+class EntitlementData {
+  /// 已處理的訂單記錄 (orderId -> OrderGrant)
+  final Map<String, OrderGrant> orders;
+  
+  /// 永久權益旗標 (skuId -> bool)
+  final Map<String, bool> entitlements;
+
+  const EntitlementData({
+    this.orders = const {},
+    this.entitlements = const {},
+  });
+
+  /// 從 JSON 建立實例
+  factory EntitlementData.fromJson(Map<String, dynamic> json) {
+    final ordersJson = json['orders'] as Map<String, dynamic>? ?? {};
+    final orders = <String, OrderGrant>{};
+    for (final entry in ordersJson.entries) {
+      orders[entry.key] = OrderGrant.fromJson(entry.value as Map<String, dynamic>);
+    }
+
+    final entitlementsJson = json['entitlements'] as Map<String, dynamic>? ?? {};
+    final entitlements = <String, bool>{};
+    for (final entry in entitlementsJson.entries) {
+      entitlements[entry.key] = entry.value as bool? ?? false;
+    }
+
+    return EntitlementData(
+      orders: orders,
+      entitlements: entitlements,
+    );
+  }
+
+  /// 轉換為 JSON
+  Map<String, dynamic> toJson() {
+    final ordersJson = <String, dynamic>{};
+    for (final entry in orders.entries) {
+      ordersJson[entry.key] = entry.value.toJson();
+    }
+
+    return {
+      'orders': ordersJson,
+      'entitlements': entitlements,
+    };
+  }
+
+  /// 建立副本並更新指定欄位
+  EntitlementData copyWith({
+    Map<String, OrderGrant>? orders,
+    Map<String, bool>? entitlements,
+  }) {
+    return EntitlementData(
+      orders: orders ?? this.orders,
+      entitlements: entitlements ?? this.entitlements,
+    );
+  }
+
+  /// 檢查訂單是否已處理
+  bool hasGrantedOrder(String orderId) {
+    return orders.containsKey(orderId);
+  }
+
+  /// 檢查是否擁有永久權益
+  bool hasEntitlement(String skuId) {
+    return entitlements[skuId] == true;
+  }
+
+  /// 新增訂單記錄
+  EntitlementData addOrder(String orderId, String skuId, int grantedAt) {
+    final newOrders = Map<String, OrderGrant>.from(orders);
+    newOrders[orderId] = OrderGrant(
+      skuId: skuId,
+      grantedAt: grantedAt,
+    );
+    return copyWith(orders: newOrders);
+  }
+
+  /// 設定永久權益
+  EntitlementData setEntitlement(String skuId, bool value) {
+    final newEntitlements = Map<String, bool>.from(entitlements);
+    newEntitlements[skuId] = value;
+    return copyWith(entitlements: newEntitlements);
+  }
+}
+
+/// 單筆訂單授權記錄
+class OrderGrant {
+  /// SKU ID
+  final String skuId;
+  
+  /// 授權時間戳記
+  final int grantedAt;
+
+  const OrderGrant({
+    required this.skuId,
+    required this.grantedAt,
+  });
+
+  /// 從 JSON 建立實例
+  factory OrderGrant.fromJson(Map<String, dynamic> json) {
+    return OrderGrant(
+      skuId: json['skuId'] as String? ?? '',
+      grantedAt: json['grantedAt'] as int? ?? 0,
+    );
+  }
+
+  /// 轉換為 JSON
+  Map<String, dynamic> toJson() {
+    return {
+      'skuId': skuId,
+      'grantedAt': grantedAt,
+    };
+  }
+}

--- a/lib/models/game_state.dart
+++ b/lib/models/game_state.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'pet.dart';
+import 'buff_models.dart';
 import 'package:idle_hippo/services/config_service.dart';
 
 /// 待提交的抽卡批次（兩階段提交用）
@@ -1186,6 +1187,7 @@ class GameState {
   final PendingGachaBatch? pendingGachaBatch;
   final CheckinState? checkin;
   final KaraokeState? karaoke; // Step23: 每日卡拉OK次數限制
+  final BuffState? buffs; // Step27-3: buff 系統
 
   const GameState({
     required this.saveVersion,
@@ -1205,6 +1207,7 @@ class GameState {
     this.pendingGachaBatch,
     this.checkin,
     this.karaoke,
+    this.buffs,
   });
 
   /// 建立初始狀態
@@ -1224,6 +1227,7 @@ class GameState {
       gacha: null,
       titles: const TitlesState(),
       karaoke: null,
+      buffs: const BuffState(),
     );
   }
 
@@ -1304,6 +1308,10 @@ class GameState {
           map.containsKey('karaoke') && map['karaoke'] is Map<String, dynamic>
           ? KaraokeState.fromMap(map['karaoke'] as Map<String, dynamic>)
           : null,
+      buffs:
+          map.containsKey('buffs') && map['buffs'] is Map<String, dynamic>
+          ? BuffState.fromMap(map['buffs'] as Map<String, dynamic>)
+          : const BuffState(),
     );
   }
 
@@ -1333,6 +1341,7 @@ class GameState {
         'pendingGachaBatch': pendingGachaBatch!.toMap(),
       if (checkin != null) 'checkin': checkin!.toMap(),
       if (karaoke != null) 'karaoke': karaoke!.toMap(),
+      if (buffs != null) 'buffs': buffs!.toMap(),
     };
   }
 
@@ -1388,6 +1397,7 @@ class GameState {
     bool? clearPendingGachaBatch,
     CheckinState? checkin,
     KaraokeState? karaoke,
+    BuffState? buffs,
   }) {
     return GameState(
       saveVersion: saveVersion ?? this.saveVersion,
@@ -1410,6 +1420,7 @@ class GameState {
           : (pendingGachaBatch ?? this.pendingGachaBatch),
       checkin: checkin ?? this.checkin,
       karaoke: karaoke ?? this.karaoke,
+      buffs: buffs ?? this.buffs,
     );
   }
 
@@ -1446,7 +1457,8 @@ class GameState {
         other.titles == titles &&
         _pendingBatchEquals(other.pendingGachaBatch, pendingGachaBatch) &&
         other.checkin == checkin &&
-        other.karaoke == karaoke;
+        other.karaoke == karaoke &&
+        other.buffs == buffs;
   }
 
   @override
@@ -1467,7 +1479,8 @@ class GameState {
         (titles?.hashCode ?? 0) ^
         (pendingGachaBatch?.hashCode ?? 0) ^
         (checkin?.hashCode ?? 0) ^
-        (karaoke?.hashCode ?? 0);
+        (karaoke?.hashCode ?? 0) ^
+        (buffs?.hashCode ?? 0);
   }
 
   bool _mapEquals(Map<String, int> a, Map<String, int> b) {

--- a/lib/models/purchase_models.dart
+++ b/lib/models/purchase_models.dart
@@ -1,14 +1,15 @@
 /// 購買相關的資料模型與抽象介面定義
-/// 
+///
 /// 提供購買商品資訊、購買事件、購買狀態等核心資料結構
+library;
 
 /// 商品資訊
 class ProductInfo {
-  final String id;       // 商品 ID（= store.* key）
-  final String name;     // UI 端自行做 i18n 映射
+  final String id; // 商品 ID（= store.* key）
+  final String name; // UI 端自行做 i18n 映射
   final String desc;
   final String image;
-  final double? price;   // Mock 可填，IAP 由 SDK 回傳
+  final double? price; // Mock 可填，IAP 由 SDK 回傳
   final String? currency;
 
   const ProductInfo({
@@ -89,10 +90,15 @@ enum LimitType { limited, unlimited, daily, monthly, first7, first30 }
 /// 購買可用性狀態
 class PurchaseAvailability {
   final bool canBuy;
-  final String? reasonKey; // i18n key: e.g. store.unavailable.daily_cap, store.unavailable.first7_expired
-  final int remaining;     // 本視窗期內剩餘次數（-1 表示無上限）
+  final String?
+  reasonKey; // i18n key: e.g. store.unavailable.daily_cap, store.unavailable.first7_expired
+  final int remaining; // 本視窗期內剩餘次數（-1 表示無上限）
 
-  const PurchaseAvailability(this.canBuy, {this.reasonKey, this.remaining = -1});
+  const PurchaseAvailability(
+    this.canBuy, {
+    this.reasonKey,
+    this.remaining = -1,
+  });
 
   @override
   bool operator ==(Object other) =>
@@ -118,11 +124,7 @@ class PurchaseRecord {
   final DailyRecord? daily;
   final MonthlyRecord? monthly;
 
-  const PurchaseRecord({
-    this.total,
-    this.daily,
-    this.monthly,
-  });
+  const PurchaseRecord({this.total, this.daily, this.monthly});
 
   Map<String, dynamic> toJson() {
     final Map<String, dynamic> json = {};
@@ -162,15 +164,9 @@ class DailyRecord {
   final String date; // YYYY-MM-DD (Asia/Taipei)
   final int count;
 
-  const DailyRecord({
-    required this.date,
-    required this.count,
-  });
+  const DailyRecord({required this.date, required this.count});
 
-  Map<String, dynamic> toJson() => {
-        'date': date,
-        'count': count,
-      };
+  Map<String, dynamic> toJson() => {'date': date, 'count': count};
 
   factory DailyRecord.fromJson(Map<String, dynamic> json) {
     return DailyRecord(
@@ -180,10 +176,7 @@ class DailyRecord {
   }
 
   DailyRecord copyWith({String? date, int? count}) {
-    return DailyRecord(
-      date: date ?? this.date,
-      count: count ?? this.count,
-    );
+    return DailyRecord(date: date ?? this.date, count: count ?? this.count);
   }
 }
 
@@ -192,28 +185,16 @@ class MonthlyRecord {
   final String ym; // YYYY-MM (Asia/Taipei)
   final int count;
 
-  const MonthlyRecord({
-    required this.ym,
-    required this.count,
-  });
+  const MonthlyRecord({required this.ym, required this.count});
 
-  Map<String, dynamic> toJson() => {
-        'ym': ym,
-        'count': count,
-      };
+  Map<String, dynamic> toJson() => {'ym': ym, 'count': count};
 
   factory MonthlyRecord.fromJson(Map<String, dynamic> json) {
-    return MonthlyRecord(
-      ym: json['ym'] as String,
-      count: json['count'] as int,
-    );
+    return MonthlyRecord(ym: json['ym'] as String, count: json['count'] as int);
   }
 
   MonthlyRecord copyWith({String? ym, int? count}) {
-    return MonthlyRecord(
-      ym: ym ?? this.ym,
-      count: count ?? this.count,
-    );
+    return MonthlyRecord(ym: ym ?? this.ym, count: count ?? this.count);
   }
 }
 
@@ -221,17 +202,11 @@ class MonthlyRecord {
 class InstallRecord {
   final String firstOpenDate; // YYYY-MM-DD (Asia/Taipei)
 
-  const InstallRecord({
-    required this.firstOpenDate,
-  });
+  const InstallRecord({required this.firstOpenDate});
 
-  Map<String, dynamic> toJson() => {
-        'firstOpenDate': firstOpenDate,
-      };
+  Map<String, dynamic> toJson() => {'firstOpenDate': firstOpenDate};
 
   factory InstallRecord.fromJson(Map<String, dynamic> json) {
-    return InstallRecord(
-      firstOpenDate: json['firstOpenDate'] as String,
-    );
+    return InstallRecord(firstOpenDate: json['firstOpenDate'] as String);
   }
 }

--- a/lib/services/config_service.dart
+++ b/lib/services/config_service.dart
@@ -149,7 +149,7 @@ class ConfigService {
   /// 取得商城配置
   Map<String, dynamic> getStoreConfig() {
     if (!_isLoaded) return {};
-    
+
     final storeConfig = _configs['store'] as Map<String, dynamic>?;
     final itemsConfig = storeConfig?['items'] as Map<String, dynamic>?;
     return itemsConfig ?? {};

--- a/lib/services/daily_tap_service.dart
+++ b/lib/services/daily_tap_service.dart
@@ -56,7 +56,13 @@ class DailyTapService {
     final block = state.dailyTap;
     final doubled = block?.adDoubledToday == true;
     final base = dailyCapBase;
-    return doubled ? base * adMultiplier : base;
+    final buffs = state.buffs;
+    final multiplier = buffs?.getDailyCapMultiplier() ?? 1.0;
+    final baseWithBuff = DecimalUtils.multiply(base.toDouble(), multiplier);
+    final capValue = doubled
+        ? DecimalUtils.multiply(baseWithBuff, adMultiplier)
+        : baseWithBuff;
+    return capValue.round();
   }
 
   // Returns (updatedState, allowedGain)

--- a/lib/services/entitlement_manager.dart
+++ b/lib/services/entitlement_manager.dart
@@ -1,107 +1,229 @@
 import 'dart:convert';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import '../models/entitlement_models.dart';
-import '../models/game_state.dart';
-import 'config_service.dart';
+
+import '../models/buff_models.dart';
 import 'game_state_service.dart';
 
-/// 權益管理器介面
-///
-/// 實際授予玩家購買後的權益（例如解鎖功能、加值道具）。
-/// 冪等性建議在實作層處理：重複授權同一權益不應造成副作用。
-abstract class EntitlementManager {
-  /// 發放權益
-  /// 
-  /// [skuId] 商品 SKU ID
-  /// [orderId] 訂單 ID，可為 null（用於恢復 non-consumable）
-  Future<void> grant({required String skuId, String? orderId});
-  
-  /// 檢查訂單是否已處理
-  bool hasGrantedOrder(String orderId);
+/// 商品效果配置
+class StoreEffectConfig {
+  final String type; // permanent, timed, instant, bundle
+  final Map<String, dynamic> effects;
+  final String? description;
+
+  const StoreEffectConfig({
+    required this.type,
+    required this.effects,
+    this.description,
+  });
+
+  factory StoreEffectConfig.fromMap(Map<String, dynamic> map) {
+    return StoreEffectConfig(
+      type: map['type'] as String,
+      effects: Map<String, dynamic>.from(map['effects'] as Map),
+      description: map['description'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'type': type,
+      'effects': effects,
+      if (description != null) 'description': description,
+    };
+  }
 }
 
-/// 完整的權益管理器實作
+/// 權益資料模型
+class EntitlementData {
+  final Map<String, bool> entitlements; // skuId -> granted
+  final Map<String, int> orders; // orderId -> timestamp
+
+  const EntitlementData({this.entitlements = const {}, this.orders = const {}});
+
+  EntitlementData copyWith({
+    Map<String, bool>? entitlements,
+    Map<String, int>? orders,
+  }) {
+    return EntitlementData(
+      entitlements: entitlements ?? this.entitlements,
+      orders: orders ?? this.orders,
+    );
+  }
+
+  EntitlementData setEntitlement(String skuId, bool granted) {
+    final newEntitlements = Map<String, bool>.from(entitlements);
+    newEntitlements[skuId] = granted;
+    return copyWith(entitlements: newEntitlements);
+  }
+
+  EntitlementData addOrder(String orderId, int timestamp) {
+    final newOrders = Map<String, int>.from(orders);
+    newOrders[orderId] = timestamp;
+    return copyWith(orders: newOrders);
+  }
+
+  bool hasEntitlement(String skuId) {
+    return entitlements[skuId] == true;
+  }
+
+  bool hasGrantedOrder(String orderId) {
+    return orders.containsKey(orderId);
+  }
+
+  factory EntitlementData.fromMap(Map<String, dynamic> map) {
+    return EntitlementData(
+      entitlements: Map<String, bool>.from(map['entitlements'] ?? {}),
+      orders: Map<String, int>.from(map['orders'] ?? {}),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {'entitlements': entitlements, 'orders': orders};
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is EntitlementData &&
+        mapEquals(other.entitlements, entitlements) &&
+        mapEquals(other.orders, orders);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    Object.hashAllUnordered(entitlements.entries),
+    Object.hashAllUnordered(orders.entries),
+  );
+}
+
+/// 權益管理器介面
+abstract class EntitlementManager {
+  /// 初始化
+  Future<void> init();
+
+  /// 發放權益
+  /// [skuId] 商品 ID
+  /// [orderId] 訂單 ID（可選，用於冪等檢查）
+  Future<void> grant({required String skuId, String? orderId});
+
+  /// 檢查是否擁有權益
+  bool hasEntitlement(String skuId);
+
+  /// 檢查訂單是否已處理
+  bool hasGrantedOrder(String orderId);
+
+  /// 清理過期的限時 buff
+  Future<void> cleanupExpiredBuffs();
+
+  /// 清除所有權益持久化資料（Debug/重置用）
+  /// - 刪除安全儲存中的紀錄
+  /// - 清空記憶體中的快取資料
+  Future<void> resetPersistedData();
+}
+
+/// 權益管理器實作
 class EntitlementManagerImpl implements EntitlementManager {
-  static const String _storageKey = 'entitlement_data';
-  
-  final ConfigService _configService;
   final GameStateService _gameStateService;
-  
-  static const FlutterSecureStorage _storage = FlutterSecureStorage();
-  
+  final FlutterSecureStorage _storage;
+  final String _storageKey = 'entitlement_data';
+
   EntitlementData _data = const EntitlementData();
-  bool _initialized = false;
+  Map<String, StoreEffectConfig> _effectsConfig = {};
 
   EntitlementManagerImpl({
-    required ConfigService configService,
     required GameStateService gameStateService,
-  }) : _configService = configService,
-       _gameStateService = gameStateService;
+    FlutterSecureStorage? storage,
+  }) : _gameStateService = gameStateService,
+       _storage = storage ?? const FlutterSecureStorage();
 
-  /// 初始化服務
-  Future<void> initialize() async {
-    if (_initialized) return;
-    
+  @override
+  Future<void> init() async {
+    await _loadEffectsConfig();
     await _loadData();
-    _initialized = true;
+  }
+
+  /// 載入商品效果配置
+  Future<void> _loadEffectsConfig() async {
+    try {
+      final jsonString = await rootBundle.loadString(
+        'assets/config/store_effects.json',
+      );
+      final Map<String, dynamic> configMap = json.decode(jsonString);
+
+      _effectsConfig = configMap.map(
+        (key, value) => MapEntry(
+          key,
+          StoreEffectConfig.fromMap(value as Map<String, dynamic>),
+        ),
+      );
+
+      debugPrint('[EntitlementManager] 載入商品效果配置: ${_effectsConfig.length} 項');
+    } catch (e) {
+      debugPrint('[EntitlementManager] 載入商品效果配置失敗: $e');
+      _effectsConfig = {};
+    }
+  }
+
+  /// 載入權益資料
+  Future<void> _loadData() async {
+    try {
+      final jsonString = await _storage.read(key: _storageKey);
+      if (jsonString != null) {
+        final Map<String, dynamic> dataMap = json.decode(jsonString);
+        _data = EntitlementData.fromMap(dataMap);
+      }
+    } catch (e) {
+      debugPrint('[EntitlementManager] 載入權益資料失敗: $e');
+      _data = const EntitlementData();
+    }
+  }
+
+  /// 儲存權益資料
+  Future<void> _saveData() async {
+    try {
+      final jsonString = json.encode(_data.toMap());
+      await _storage.write(key: _storageKey, value: jsonString);
+    } catch (e) {
+      debugPrint('[EntitlementManager] 儲存權益資料失敗: $e');
+    }
   }
 
   @override
   Future<void> grant({required String skuId, String? orderId}) async {
-    if (!_initialized) {
-      await initialize();
+    final resolvedSkuId = _resolveSkuId(skuId);
+
+    // 冪等檢查
+    if (orderId != null && _data.hasGrantedOrder(orderId)) {
+      debugPrint('[EntitlementManager] 訂單已處理，跳過: $orderId');
+      return;
     }
 
-    // 冪等處理邏輯
-    
-    // 檢查是否為 non-consumable
-    final isNonConsumable = _isNonConsumable(skuId);
-    
-    if (isNonConsumable) {
-      // non-consumable: 檢查永久權益是否已設定
-      if (_data.hasEntitlement(skuId)) {
-        debugPrint('[EntitlementManager] 永久權益已存在，跳過: $skuId');
-        return;
-      }
-      
-      // 若有 orderId，也檢查是否已處理過
-      if (orderId != null && _data.hasGrantedOrder(orderId)) {
-        debugPrint('[EntitlementManager] 訂單已處理，跳過: $orderId');
-        return;
-      }
-      
-      // 設定永久權益
-      _data = _data.setEntitlement(skuId, true);
-      
-      // 記錄訂單（如果有 orderId）
-      if (orderId != null) {
-        final now = DateTime.now().millisecondsSinceEpoch;
-        _data = _data.addOrder(orderId, skuId, now);
-      }
-      
-      debugPrint('[EntitlementManager] 發放永久權益: $skuId');
-    } else {
-      // consumable: 檢查訂單是否已處理
-      if (orderId != null && _data.hasGrantedOrder(orderId)) {
-        debugPrint('[EntitlementManager] 消耗品訂單已處理，跳過: $orderId');
-        return;
-      }
-      
-      // 發放消耗品資源
-      await _grantConsumableResources(skuId);
-      
-      // 記錄訂單
-      if (orderId != null) {
-        final now = DateTime.now().millisecondsSinceEpoch;
-        _data = _data.addOrder(orderId, skuId, now);
-      }
-      
-      debugPrint('[EntitlementManager] 發放消耗品: $skuId');
+    // 取得商品配置
+    final config = _effectsConfig[resolvedSkuId];
+    if (config == null) {
+      debugPrint('[EntitlementManager] 找不到商品配置: $skuId');
+      return;
     }
-    
-    // 保存資料
+
+    // 處理商品效果
+    await _processStoreItem(resolvedSkuId, config, orderId);
+
+    // 記錄訂單
+    if (orderId != null) {
+      final now = DateTime.now().millisecondsSinceEpoch;
+      _data = _data.addOrder(orderId, now);
+    }
+
+    // 儲存資料
     await _saveData();
+  }
+
+  @override
+  bool hasEntitlement(String skuId) {
+    final resolvedSkuId = _resolveSkuId(skuId);
+    return _data.hasEntitlement(resolvedSkuId);
   }
 
   @override
@@ -109,174 +231,266 @@ class EntitlementManagerImpl implements EntitlementManager {
     return _data.hasGrantedOrder(orderId);
   }
 
-  /// 檢查是否為 non-consumable 商品
-  bool _isNonConsumable(String skuId) {
-    final storeConfig = _configService.getStoreConfig();
-    
-    // 移除 store. 前綴來查找配置
-    final configKey = skuId.startsWith('store.') ? skuId : 'store.$skuId';
-    final itemConfig = storeConfig['items']?[configKey] as Map<String, dynamic>?;
-    
-    if (itemConfig == null) {
-      debugPrint('[EntitlementManager] 找不到商品配置: $configKey');
-      return false;
+  /// 將輸入的 SKU 標準化為配置中使用的鍵值
+  String _resolveSkuId(String skuId) {
+    if (_effectsConfig.containsKey(skuId)) {
+      return skuId;
     }
-    
-    final limitType = itemConfig['purchase_limit_type'] as String?;
-    final maxCount = itemConfig['purchase_max_count'] as int?;
-    
-    // limited 且 max_count 為 1 的視為 non-consumable
-    return limitType == 'limited' && maxCount == 1;
-  }
 
-  /// 發放消耗品資源
-  Future<void> _grantConsumableResources(String skuId) async {
-    // 根據 skuId 發放對應資源
-    switch (skuId) {
-      case 'card_click_2x_30m':
-      case 'store.card_click_2x_30m':
-        // 加 30 分鐘點擊 2x buff
-        await _addBuffTime('click_2x', 30 * 60);
-        break;
-        
-      case 'card_idle_2x_1h':
-      case 'store.card_idle_2x_1h':
-        // 加 1 小時掛機 2x buff
-        await _addBuffTime('idle_2x', 60 * 60);
-        break;
-        
-      case 'card_offline_once_6h':
-      case 'store.card_offline_once_6h':
-        // 加 6 小時離線收益
-        await _addOfflineTime(6 * 60 * 60);
-        break;
-        
-      case 'ticket_pet_single':
-      case 'store.ticket_pet_single':
-        // 加 1 張寵物抽獎券
-        await _addTickets('pet', 1);
-        break;
-        
-      case 'ticket_pet_10plus1':
-      case 'store.ticket_pet_10plus1':
-        // 加 11 張寵物抽獎券
-        await _addTickets('pet', 11);
-        break;
-        
-      default:
-        debugPrint('[EntitlementManager] 未知的消耗品類型: $skuId');
-    }
-  }
-
-  /// 增加 buff 時間
-  Future<void> _addBuffTime(String buffType, int seconds) async {
-    // 透過 GameStateService 更新狀態
-    final currentState = _gameStateService.currentState;
-    final stateData = jsonDecode(currentState.toJson()) as Map<String, dynamic>;
-    final buffs = Map<String, dynamic>.from(stateData['buffs'] ?? {});
-    final currentEndTime = buffs[buffType] as int? ?? 0;
-    final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-    
-    // 如果 buff 還在生效，延長時間；否則從現在開始
-    final newEndTime = currentEndTime > now 
-        ? currentEndTime + seconds
-        : now + seconds;
-    
-    buffs[buffType] = newEndTime;
-    stateData['buffs'] = buffs;
-    
-    // 建立新的狀態
-    final newState = GameState.fromJson(jsonEncode(stateData));
-    await _gameStateService.updateGameState(newState);
-  }
-
-  /// 增加離線時間
-  Future<void> _addOfflineTime(int seconds) async {
-    final currentState = _gameStateService.currentState;
-    final stateData = jsonDecode(currentState.toJson()) as Map<String, dynamic>;
-    final currentOfflineTime = stateData['offlineTime'] as int? ?? 0;
-    stateData['offlineTime'] = currentOfflineTime + seconds;
-    
-    final newState = GameState.fromJson(jsonEncode(stateData));
-    await _gameStateService.updateGameState(newState);
-  }
-
-  /// 增加抽獎券
-  Future<void> _addTickets(String ticketType, int count) async {
-    final currentState = _gameStateService.currentState;
-    final stateData = jsonDecode(currentState.toJson()) as Map<String, dynamic>;
-    final tickets = Map<String, dynamic>.from(stateData['tickets'] ?? {});
-    final currentCount = tickets[ticketType] as int? ?? 0;
-    tickets[ticketType] = currentCount + count;
-    stateData['tickets'] = tickets;
-    
-    final newState = GameState.fromJson(jsonEncode(stateData));
-    await _gameStateService.updateGameState(newState);
-  }
-
-  /// 載入資料
-  Future<void> _loadData() async {
-    try {
-      final jsonStr = await _storage.read(key: _storageKey);
-      if (jsonStr != null && jsonStr.isNotEmpty) {
-        final json = jsonDecode(jsonStr) as Map<String, dynamic>;
-        _data = EntitlementData.fromJson(json);
+    if (!skuId.startsWith('store.')) {
+      final prefixed = 'store.$skuId';
+      if (_effectsConfig.containsKey(prefixed)) {
+        return prefixed;
       }
-    } catch (e) {
-      debugPrint('[EntitlementManager] 載入資料失敗: $e');
-      _data = const EntitlementData();
+    } else {
+      final unprefixed = skuId.substring('store.'.length);
+      if (_effectsConfig.containsKey(unprefixed)) {
+        return unprefixed;
+      }
+    }
+
+    return skuId;
+  }
+
+  @override
+  Future<void> cleanupExpiredBuffs() async {
+    final currentState = _gameStateService.currentState;
+    final currentBuffs = currentState.buffs;
+
+    if (currentBuffs == null) return;
+
+    final currentTimeMs = DateTime.now().millisecondsSinceEpoch;
+    final cleanedBuffs = currentBuffs.cleanupExpired(currentTimeMs);
+
+    if (cleanedBuffs != currentBuffs) {
+      final newState = currentState.copyWith(buffs: cleanedBuffs);
+      await _gameStateService.updateGameState(newState);
+      debugPrint('[EntitlementManager] 清理過期 buff');
     }
   }
 
-  /// 保存資料
-  Future<void> _saveData() async {
+  @override
+  Future<void> resetPersistedData() async {
     try {
-      final jsonStr = jsonEncode(_data.toJson());
-      await _storage.write(key: _storageKey, value: jsonStr);
+      await _storage.delete(key: _storageKey);
+      _data = const EntitlementData();
+      debugPrint('[EntitlementManager] 已清除權益持久化資料');
     } catch (e) {
-      debugPrint('[EntitlementManager] 保存資料失敗: $e');
+      debugPrint('[EntitlementManager] 清除權益持久化資料失敗: $e');
     }
+  }
+
+  /// 處理商品項目
+  Future<void> _processStoreItem(
+    String skuId,
+    StoreEffectConfig config,
+    String? orderId,
+  ) async {
+    switch (config.type) {
+      case 'permanent':
+        await _grantPermanentEffects(skuId, config.effects);
+        break;
+      case 'timed':
+        await _grantTimedBuffs(config.effects);
+        break;
+      case 'instant':
+        await _grantInstantEffects(config.effects);
+        break;
+      case 'bundle':
+        await _grantBundleEffects(config.effects);
+        break;
+      default:
+        debugPrint('[EntitlementManager] 未知的商品類型: ${config.type}');
+    }
+  }
+
+  /// 發放永久效果
+  Future<void> _grantPermanentEffects(
+    String skuId,
+    Map<String, dynamic> effects,
+  ) async {
+    // 檢查是否已擁有
+    if (_data.hasEntitlement(skuId)) {
+      debugPrint('[EntitlementManager] 永久權益已擁有，跳過: $skuId');
+      return;
+    }
+
+    // 設定永久權益
+    _data = _data.setEntitlement(skuId, true);
+
+    // 更新遊戲狀態中的永久 buff
+    final currentState = _gameStateService.currentState;
+    final currentBuffs = currentState.buffs ?? const BuffState();
+
+    var newPermanent = currentBuffs.permanent;
+
+    // 根據效果類型更新永久權益
+    if (effects.containsKey('clickBoost')) {
+      final clickValue = effects['clickBoost'];
+      if (clickValue is num && clickValue > 1.0) {
+        newPermanent = newPermanent.copyWith(clickBoost: clickValue.toDouble());
+      }
+    }
+
+    if (effects.containsKey('idleBoost')) {
+      final idleValue = effects['idleBoost'];
+      if (idleValue is num && idleValue > 1.0) {
+        newPermanent = newPermanent.copyWith(idleBoost: idleValue.toDouble());
+      }
+    }
+
+    if (effects.containsKey('offlineExtended') &&
+        effects['offlineExtended'] == true) {
+      newPermanent = newPermanent.copyWith(offlineExtended: true);
+    }
+
+    if (effects.containsKey('capIncreased') &&
+        effects['capIncreased'] == true) {
+      newPermanent = newPermanent.copyWith(capIncreased: true);
+    }
+
+    final newBuffs = currentBuffs.copyWith(permanent: newPermanent);
+    final newState = currentState.copyWith(buffs: newBuffs);
+
+    await _gameStateService.updateGameState(newState);
+    debugPrint('[EntitlementManager] 發放永久效果: $skuId, 效果: $effects');
+  }
+
+  /// 發放限時 buff
+  Future<void> _grantTimedBuffs(Map<String, dynamic> effects) async {
+    final currentState = _gameStateService.currentState;
+    final currentBuffs = currentState.buffs ?? const BuffState();
+    final currentTimeMs = DateTime.now().millisecondsSinceEpoch;
+
+    var newBuffs = currentBuffs;
+
+    // 處理各種限時 buff
+    for (final entry in effects.entries) {
+      final buffType = entry.key;
+      final buffData = entry.value as Map<String, dynamic>;
+      final multiplier = (buffData['multiplier'] as num).toDouble();
+      final durationMinutes = (buffData['durationMinutes'] as num).toInt();
+      final durationMs = durationMinutes * 60 * 1000;
+
+      newBuffs = newBuffs.addOrExtendBuff(
+        type: buffType,
+        multiplier: multiplier,
+        durationMs: durationMs,
+        currentTimeMs: currentTimeMs,
+      );
+    }
+
+    final newState = currentState.copyWith(buffs: newBuffs);
+    await _gameStateService.updateGameState(newState);
+    debugPrint('[EntitlementManager] 發放限時 buff: $effects');
+  }
+
+  /// 發放即時效果
+  Future<void> _grantInstantEffects(Map<String, dynamic> effects) async {
+    final currentState = _gameStateService.currentState;
+    var newState = currentState;
+
+    // 處理各種即時效果
+    if (effects.containsKey('memePoints')) {
+      final points = (effects['memePoints'] as num).toInt();
+      newState = newState.copyWith(memePoints: newState.memePoints + points);
+    }
+
+    if (effects.containsKey('petTickets')) {
+      final tickets = (effects['petTickets'] as num).toInt();
+      newState = newState.copyWith(petTickets: newState.petTickets + tickets);
+    }
+
+    await _gameStateService.updateGameState(newState);
+    debugPrint('[EntitlementManager] 發放即時效果: $effects');
+  }
+
+  /// 發放組合包效果
+  Future<void> _grantBundleEffects(Map<String, dynamic> effects) async {
+    // 組合包包含多種效果類型
+    if (effects.containsKey('permanent')) {
+      await _grantPermanentEffects(
+        'bundle_permanent',
+        effects['permanent'] as Map<String, dynamic>,
+      );
+    }
+
+    if (effects.containsKey('timed')) {
+      await _grantTimedBuffs(effects['timed'] as Map<String, dynamic>);
+    }
+
+    if (effects.containsKey('instant')) {
+      await _grantInstantEffects(effects['instant'] as Map<String, dynamic>);
+    }
+
+    debugPrint('[EntitlementManager] 發放組合包效果: $effects');
   }
 }
 
-/// 簡易的記憶體 Mock 版本（測試用）
+/// Mock 權益管理器（用於測試）
 class MockEntitlementManager implements EntitlementManager {
-  final List<String> granted = <String>[];
-  final Set<String> processedOrders = <String>{};
-  final Set<String> permanentEntitlements = <String>{};
+  final List<String> grantedEntitlements = []; // 改為 List 以支援重複發放
+  final Set<String> processedOrders = {};
+  final Set<String> permanentEntitlements = {}; // 追蹤永久權益
+
+  /// 向後兼容的 getter
+  List<String> get granted => grantedEntitlements;
+
+  @override
+  Future<void> init() async {
+    // Mock 不需要初始化
+  }
 
   @override
   Future<void> grant({required String skuId, String? orderId}) async {
     // 冪等檢查：如果有 orderId 且已處理過，則跳過
     if (orderId != null && processedOrders.contains(orderId)) {
-      debugPrint('[MockEntitlementManager] 訂單已處理，跳過: $orderId');
       return;
     }
-    
-    // 簡單的商品類型判斷（基於命名規則）
-    final isNonConsumable = skuId.contains('perm') || skuId.contains('cap');
-    
+
+    // 判斷是否為 non-consumable（永久商品）
+    final isNonConsumable = _isNonConsumableProduct(skuId);
+
     if (isNonConsumable) {
-      // non-consumable: 檢查是否已經擁有永久權益
+      // non-consumable: 檢查是否已擁有
       if (permanentEntitlements.contains(skuId)) {
-        debugPrint('[MockEntitlementManager] 永久權益已存在，跳過: $skuId');
-        return;
+        return; // 已擁有，跳過
       }
-      
-      // 設定永久權益
       permanentEntitlements.add(skuId);
-      granted.add(skuId);
-      debugPrint('[MockEntitlementManager] grant => $skuId');
-    } else {
-      // consumable: 每次都發放
-      granted.add(skuId);
-      debugPrint('[MockEntitlementManager] grant => $skuId');
     }
-    
+
+    // 發放權益
+    grantedEntitlements.add(skuId);
+
     // 記錄訂單
     if (orderId != null) {
       processedOrders.add(orderId);
     }
+  }
+
+  @override
+  bool hasEntitlement(String skuId) {
+    return permanentEntitlements.contains(skuId);
+  }
+
+  /// 判斷是否為 non-consumable 商品
+  bool _isNonConsumableProduct(String skuId) {
+    // 根據 SKU 命名規則判斷
+    return skuId.contains('_perm') ||
+        skuId.contains('_permanent') ||
+        skuId.startsWith('card_') && skuId.contains('_perm');
+  }
+
+  @override
+  Future<void> cleanupExpiredBuffs() async {
+    // Mock 不需要清理
+  }
+
+  @override
+  Future<void> resetPersistedData() async {
+    grantedEntitlements.clear();
+    processedOrders.clear();
+    permanentEntitlements.clear();
   }
 
   @override

--- a/lib/services/entitlement_manager.dart
+++ b/lib/services/entitlement_manager.dart
@@ -1,23 +1,286 @@
+import 'dart:convert';
 import 'package:flutter/foundation.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import '../models/entitlement_models.dart';
+import '../models/game_state.dart';
+import 'config_service.dart';
+import 'game_state_service.dart';
 
 /// 權益管理器介面
 ///
 /// 實際授予玩家購買後的權益（例如解鎖功能、加值道具）。
 /// 冪等性建議在實作層處理：重複授權同一權益不應造成副作用。
 abstract class EntitlementManager {
-  Future<void> grant(String entitlementKey);
+  /// 發放權益
+  /// 
+  /// [skuId] 商品 SKU ID
+  /// [orderId] 訂單 ID，可為 null（用於恢復 non-consumable）
+  Future<void> grant({required String skuId, String? orderId});
+  
+  /// 檢查訂單是否已處理
+  bool hasGrantedOrder(String orderId);
+}
+
+/// 完整的權益管理器實作
+class EntitlementManagerImpl implements EntitlementManager {
+  static const String _storageKey = 'entitlement_data';
+  
+  final ConfigService _configService;
+  final GameStateService _gameStateService;
+  
+  static const FlutterSecureStorage _storage = FlutterSecureStorage();
+  
+  EntitlementData _data = const EntitlementData();
+  bool _initialized = false;
+
+  EntitlementManagerImpl({
+    required ConfigService configService,
+    required GameStateService gameStateService,
+  }) : _configService = configService,
+       _gameStateService = gameStateService;
+
+  /// 初始化服務
+  Future<void> initialize() async {
+    if (_initialized) return;
+    
+    await _loadData();
+    _initialized = true;
+  }
+
+  @override
+  Future<void> grant({required String skuId, String? orderId}) async {
+    if (!_initialized) {
+      await initialize();
+    }
+
+    // 冪等處理邏輯
+    
+    // 檢查是否為 non-consumable
+    final isNonConsumable = _isNonConsumable(skuId);
+    
+    if (isNonConsumable) {
+      // non-consumable: 檢查永久權益是否已設定
+      if (_data.hasEntitlement(skuId)) {
+        debugPrint('[EntitlementManager] 永久權益已存在，跳過: $skuId');
+        return;
+      }
+      
+      // 若有 orderId，也檢查是否已處理過
+      if (orderId != null && _data.hasGrantedOrder(orderId)) {
+        debugPrint('[EntitlementManager] 訂單已處理，跳過: $orderId');
+        return;
+      }
+      
+      // 設定永久權益
+      _data = _data.setEntitlement(skuId, true);
+      
+      // 記錄訂單（如果有 orderId）
+      if (orderId != null) {
+        final now = DateTime.now().millisecondsSinceEpoch;
+        _data = _data.addOrder(orderId, skuId, now);
+      }
+      
+      debugPrint('[EntitlementManager] 發放永久權益: $skuId');
+    } else {
+      // consumable: 檢查訂單是否已處理
+      if (orderId != null && _data.hasGrantedOrder(orderId)) {
+        debugPrint('[EntitlementManager] 消耗品訂單已處理，跳過: $orderId');
+        return;
+      }
+      
+      // 發放消耗品資源
+      await _grantConsumableResources(skuId);
+      
+      // 記錄訂單
+      if (orderId != null) {
+        final now = DateTime.now().millisecondsSinceEpoch;
+        _data = _data.addOrder(orderId, skuId, now);
+      }
+      
+      debugPrint('[EntitlementManager] 發放消耗品: $skuId');
+    }
+    
+    // 保存資料
+    await _saveData();
+  }
+
+  @override
+  bool hasGrantedOrder(String orderId) {
+    return _data.hasGrantedOrder(orderId);
+  }
+
+  /// 檢查是否為 non-consumable 商品
+  bool _isNonConsumable(String skuId) {
+    final storeConfig = _configService.getStoreConfig();
+    
+    // 移除 store. 前綴來查找配置
+    final configKey = skuId.startsWith('store.') ? skuId : 'store.$skuId';
+    final itemConfig = storeConfig['items']?[configKey] as Map<String, dynamic>?;
+    
+    if (itemConfig == null) {
+      debugPrint('[EntitlementManager] 找不到商品配置: $configKey');
+      return false;
+    }
+    
+    final limitType = itemConfig['purchase_limit_type'] as String?;
+    final maxCount = itemConfig['purchase_max_count'] as int?;
+    
+    // limited 且 max_count 為 1 的視為 non-consumable
+    return limitType == 'limited' && maxCount == 1;
+  }
+
+  /// 發放消耗品資源
+  Future<void> _grantConsumableResources(String skuId) async {
+    // 根據 skuId 發放對應資源
+    switch (skuId) {
+      case 'card_click_2x_30m':
+      case 'store.card_click_2x_30m':
+        // 加 30 分鐘點擊 2x buff
+        await _addBuffTime('click_2x', 30 * 60);
+        break;
+        
+      case 'card_idle_2x_1h':
+      case 'store.card_idle_2x_1h':
+        // 加 1 小時掛機 2x buff
+        await _addBuffTime('idle_2x', 60 * 60);
+        break;
+        
+      case 'card_offline_once_6h':
+      case 'store.card_offline_once_6h':
+        // 加 6 小時離線收益
+        await _addOfflineTime(6 * 60 * 60);
+        break;
+        
+      case 'ticket_pet_single':
+      case 'store.ticket_pet_single':
+        // 加 1 張寵物抽獎券
+        await _addTickets('pet', 1);
+        break;
+        
+      case 'ticket_pet_10plus1':
+      case 'store.ticket_pet_10plus1':
+        // 加 11 張寵物抽獎券
+        await _addTickets('pet', 11);
+        break;
+        
+      default:
+        debugPrint('[EntitlementManager] 未知的消耗品類型: $skuId');
+    }
+  }
+
+  /// 增加 buff 時間
+  Future<void> _addBuffTime(String buffType, int seconds) async {
+    // 透過 GameStateService 更新狀態
+    final currentState = _gameStateService.currentState;
+    final stateData = jsonDecode(currentState.toJson()) as Map<String, dynamic>;
+    final buffs = Map<String, dynamic>.from(stateData['buffs'] ?? {});
+    final currentEndTime = buffs[buffType] as int? ?? 0;
+    final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    
+    // 如果 buff 還在生效，延長時間；否則從現在開始
+    final newEndTime = currentEndTime > now 
+        ? currentEndTime + seconds
+        : now + seconds;
+    
+    buffs[buffType] = newEndTime;
+    stateData['buffs'] = buffs;
+    
+    // 建立新的狀態
+    final newState = GameState.fromJson(jsonEncode(stateData));
+    await _gameStateService.updateGameState(newState);
+  }
+
+  /// 增加離線時間
+  Future<void> _addOfflineTime(int seconds) async {
+    final currentState = _gameStateService.currentState;
+    final stateData = jsonDecode(currentState.toJson()) as Map<String, dynamic>;
+    final currentOfflineTime = stateData['offlineTime'] as int? ?? 0;
+    stateData['offlineTime'] = currentOfflineTime + seconds;
+    
+    final newState = GameState.fromJson(jsonEncode(stateData));
+    await _gameStateService.updateGameState(newState);
+  }
+
+  /// 增加抽獎券
+  Future<void> _addTickets(String ticketType, int count) async {
+    final currentState = _gameStateService.currentState;
+    final stateData = jsonDecode(currentState.toJson()) as Map<String, dynamic>;
+    final tickets = Map<String, dynamic>.from(stateData['tickets'] ?? {});
+    final currentCount = tickets[ticketType] as int? ?? 0;
+    tickets[ticketType] = currentCount + count;
+    stateData['tickets'] = tickets;
+    
+    final newState = GameState.fromJson(jsonEncode(stateData));
+    await _gameStateService.updateGameState(newState);
+  }
+
+  /// 載入資料
+  Future<void> _loadData() async {
+    try {
+      final jsonStr = await _storage.read(key: _storageKey);
+      if (jsonStr != null && jsonStr.isNotEmpty) {
+        final json = jsonDecode(jsonStr) as Map<String, dynamic>;
+        _data = EntitlementData.fromJson(json);
+      }
+    } catch (e) {
+      debugPrint('[EntitlementManager] 載入資料失敗: $e');
+      _data = const EntitlementData();
+    }
+  }
+
+  /// 保存資料
+  Future<void> _saveData() async {
+    try {
+      final jsonStr = jsonEncode(_data.toJson());
+      await _storage.write(key: _storageKey, value: jsonStr);
+    } catch (e) {
+      debugPrint('[EntitlementManager] 保存資料失敗: $e');
+    }
+  }
 }
 
 /// 簡易的記憶體 Mock 版本（測試用）
 class MockEntitlementManager implements EntitlementManager {
   final List<String> granted = <String>[];
+  final Set<String> processedOrders = <String>{};
+  final Set<String> permanentEntitlements = <String>{};
 
   @override
-  Future<void> grant(String entitlementKey) async {
-    // 冪等保護：避免重複插入
-    if (!granted.contains(entitlementKey)) {
-      granted.add(entitlementKey);
-      debugPrint('[Entitlement] grant => $entitlementKey');
+  Future<void> grant({required String skuId, String? orderId}) async {
+    // 冪等檢查：如果有 orderId 且已處理過，則跳過
+    if (orderId != null && processedOrders.contains(orderId)) {
+      debugPrint('[MockEntitlementManager] 訂單已處理，跳過: $orderId');
+      return;
     }
+    
+    // 簡單的商品類型判斷（基於命名規則）
+    final isNonConsumable = skuId.contains('perm') || skuId.contains('cap');
+    
+    if (isNonConsumable) {
+      // non-consumable: 檢查是否已經擁有永久權益
+      if (permanentEntitlements.contains(skuId)) {
+        debugPrint('[MockEntitlementManager] 永久權益已存在，跳過: $skuId');
+        return;
+      }
+      
+      // 設定永久權益
+      permanentEntitlements.add(skuId);
+      granted.add(skuId);
+      debugPrint('[MockEntitlementManager] grant => $skuId');
+    } else {
+      // consumable: 每次都發放
+      granted.add(skuId);
+      debugPrint('[MockEntitlementManager] grant => $skuId');
+    }
+    
+    // 記錄訂單
+    if (orderId != null) {
+      processedOrders.add(orderId);
+    }
+  }
+
+  @override
+  bool hasGrantedOrder(String orderId) {
+    return processedOrders.contains(orderId);
   }
 }

--- a/lib/services/equipment_service.dart
+++ b/lib/services/equipment_service.dart
@@ -239,10 +239,22 @@ class EquipmentService {
     return DecimalUtils.sum(bonuses);
   }
 
-  double computeTapGain(GameState state) {
+  double computeTapGain(
+    GameState state, {
+    int? currentTimeMs,
+  }) {
     final baseVal = _config.getValue('game.tap.base', defaultValue: 1);
     final base = baseVal is num ? baseVal.toDouble() : 1.0;
-    return DecimalUtils.add(base, sumTapBonus(state));
+    final additiveGain = DecimalUtils.add(base, sumTapBonus(state));
+
+    final buffs = state.buffs;
+    if (buffs == null) {
+      return additiveGain;
+    }
+
+    final nowMs = currentTimeMs ?? DateTime.now().millisecondsSinceEpoch;
+    final multiplier = buffs.getClickMultiplier(nowMs);
+    return DecimalUtils.multiply(additiveGain, multiplier);
   }
 
   int? getNextCost(String id, int currentLevel) {

--- a/lib/services/idle_income_service.dart
+++ b/lib/services/idle_income_service.dart
@@ -47,8 +47,14 @@ class IdleIncomeService {
 
     // 放置裝備加成
     double equipmentBonus = 0.0;
+    double buffMultiplier = 1.0;
     if (_currentGameState != null) {
       equipmentBonus = _equipmentService.sumIdleBonus(_currentGameState!);
+      final buffs = _currentGameState!.buffs;
+      if (buffs != null) {
+        final nowMs = DateTime.now().millisecondsSinceEpoch;
+        buffMultiplier = buffs.getIdleMultiplier(nowMs);
+      }
     }
 
     // 寵物加成：始終以 PetService 的即時狀態為準
@@ -60,7 +66,8 @@ class IdleIncomeService {
     }
     petBonus = _petService.getCurrentPetIdlePerSec();
 
-    return DecimalUtils.add(DecimalUtils.add(base, equipmentBonus), petBonus);
+    final additive = DecimalUtils.add(DecimalUtils.add(base, equipmentBonus), petBonus);
+    return DecimalUtils.multiply(additive, buffMultiplier);
   }
 
   /// 測試用途：設定 idle_per_sec 覆寫（傳入 null 以清除）

--- a/lib/services/integrated_store_service.dart
+++ b/lib/services/integrated_store_service.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'package:flutter/foundation.dart';
-import 'package:meta/meta.dart';
 import '../models/purchase_models.dart';
 import '../services/config_service.dart';
 import '../services/secure_save_service.dart';
@@ -9,13 +8,16 @@ import '../services/purchase_limiter.dart';
 import '../services/purchase_service.dart';
 import '../services/mock_purchase_service.dart';
 import '../services/mock_rewarded_ad_service.dart';
+import '../services/entitlement_manager.dart';
+import '../services/game_state_service.dart';
 
 /// 整合的商城服務
-/// 
+///
 /// 結合新的購買抽象層與現有的商城功能
 /// 提供統一的商城操作介面
 class IntegratedStoreService extends ChangeNotifier {
-  static final IntegratedStoreService _instance = IntegratedStoreService._internal();
+  static final IntegratedStoreService _instance =
+      IntegratedStoreService._internal();
   factory IntegratedStoreService() => _instance;
   IntegratedStoreService._internal();
 
@@ -23,13 +25,14 @@ class IntegratedStoreService extends ChangeNotifier {
   @visibleForTesting
   IntegratedStoreService.testable();
 
-  late final ConfigService _configService;
-  late final SecureSaveService _saveService;
-  late final PurchaseRepository _repository;
-  late final PurchaseLimiter _limiter;
-  late final PurchaseService _purchaseService;
-  late final RewardedAdService _rewardedAdService;
-  
+  late ConfigService _configService;
+  late PurchaseRepository _repository;
+  late PurchaseLimiter _limiter;
+  late PurchaseService _purchaseService;
+  late RewardedAdService _rewardedAdService;
+  late GameStateService _gameStateService;
+  late EntitlementManager _entitlementManager;
+
   StreamSubscription<PurchaseEvent>? _purchaseSubscription;
   bool _initialized = false;
   bool _disposed = false;
@@ -41,15 +44,23 @@ class IntegratedStoreService extends ChangeNotifier {
     ConfigService? configService,
     SecureSaveService? saveService,
     bool useMockServices = true,
+    GameStateService? gameStateService,
+    EntitlementManager? entitlementManager,
   }) async {
     if (_initialized) return;
 
     _disposed = false;
     _configService = configService ?? ConfigService();
-    _saveService = saveService ?? SecureSaveService();
     _repository = PurchaseRepository();
     _limiter = PurchaseLimiterImpl(_configService, _repository);
-    
+
+    // 遊戲狀態與權益管理（確保購買後能發放效果）
+    _gameStateService = gameStateService ?? GameStateService();
+    await _gameStateService.initialize();
+    _entitlementManager = entitlementManager ??
+        EntitlementManagerImpl(gameStateService: _gameStateService);
+    await _entitlementManager.init();
+
     // 根據參數決定使用 Mock 或真實服務
     if (useMockServices) {
       _purchaseService = MockPurchaseService();
@@ -60,37 +71,10 @@ class IntegratedStoreService extends ChangeNotifier {
       _rewardedAdService = MockRewardedAdService();
     }
 
-  /// 取得新手期剩餘時間元件（天/時/分），供 UI 以 i18n 模板格式化
-  Future<Map<String, int>?> getFirstPeriodRemaining(String productId) async {
-    if (!_initialized) return null;
-
-    final storeConfig = _configService.getStoreConfig();
-    final productConfig = storeConfig[productId] as Map<String, dynamic>?;
-    if (productConfig == null) return null;
-
-    final type = productConfig['purchase_limit_type'] as String?;
-    if (type != 'first7' && type != 'first30') return null;
-
-    final daysTotal = type == 'first7' ? 7 : 30;
-    final nowLocal = _getCurrentTaipeiTime();
-    final installRecord = await _repository.ensureInstallRecord(nowLocal);
-    final firstOpen = DateTime.parse(installRecord.firstOpenDate);
-    final endAt = firstOpen.add(Duration(days: daysTotal));
-    final diff = endAt.difference(nowLocal);
-    if (diff.inSeconds <= 0) return null;
-
-    final d = diff.inDays;
-    final h = diff.inHours % 24;
-    final m = diff.inMinutes % 60;
-    return {
-      'days': d,
-      'hours': h,
-      'minutes': m,
-    };
-  }
-
     // 監聽購買事件
-    _purchaseSubscription = _purchaseService.purchaseStream.listen(_onPurchaseEvent);
+    _purchaseSubscription = _purchaseService.purchaseStream.listen(
+      _onPurchaseEvent,
+    );
 
     _initialized = true;
   }
@@ -99,9 +83,12 @@ class IntegratedStoreService extends ChangeNotifier {
   Future<PurchaseAvailability> getAvailability(String productId) async {
     if (!_initialized) {
       // 服務未初始化時，返回不可購買狀態
-      return const PurchaseAvailability(false, reasonKey: 'store.not_initialized');
+      return const PurchaseAvailability(
+        false,
+        reasonKey: 'store.not_initialized',
+      );
     }
-    
+
     try {
       final nowLocal = _getCurrentTaipeiTime();
       return await _limiter.availability(productId, nowLocal);
@@ -116,33 +103,40 @@ class IntegratedStoreService extends ChangeNotifier {
     if (!_initialized) {
       throw Exception('IntegratedStoreService not initialized');
     }
-    
+
     final storeConfig = _configService.getStoreConfig();
     final productConfig = storeConfig[productId] as Map<String, dynamic>?;
-    
+
     if (productConfig == null) {
       throw Exception('Product not found: $productId');
     }
 
     final adsPay = productConfig['ads_pay'] as bool? ?? false;
-    
+
     if (adsPay) {
       // 廣告購買
-      final result = await _rewardedAdService.show('store_item', productId: productId);
+      final result = await _rewardedAdService.show(
+        'store_item',
+        productId: productId,
+      );
       if (result == RewardedStatus.rewarded) {
         // 廣告成功，觸發購買成功事件
-        await _onPurchaseEvent(PurchaseEvent(
-          productId: productId,
-          status: PurchaseStatus.success,
-          message: 'Rewarded ad completed',
-        ));
+        await _onPurchaseEvent(
+          PurchaseEvent(
+            productId: productId,
+            status: PurchaseStatus.success,
+            message: 'Rewarded ad completed',
+          ),
+        );
       } else {
         // 廣告失敗或取消
-        await _onPurchaseEvent(PurchaseEvent(
-          productId: productId,
-          status: PurchaseStatus.canceled,
-          message: 'Rewarded ad not completed',
-        ));
+        await _onPurchaseEvent(
+          PurchaseEvent(
+            productId: productId,
+            status: PurchaseStatus.canceled,
+            message: 'Rewarded ad not completed',
+          ),
+        );
       }
     } else {
       // IAP 購買
@@ -177,19 +171,26 @@ class IntegratedStoreService extends ChangeNotifier {
       throw Exception('Product not found: $productId');
     }
 
-    final result = await _rewardedAdService.show('store_item', productId: productId);
+    final result = await _rewardedAdService.show(
+      'store_item',
+      productId: productId,
+    );
     if (result == RewardedStatus.rewarded) {
-      await _onPurchaseEvent(PurchaseEvent(
-        productId: productId,
-        status: PurchaseStatus.success,
-        message: 'Rewarded ad completed',
-      ));
+      await _onPurchaseEvent(
+        PurchaseEvent(
+          productId: productId,
+          status: PurchaseStatus.success,
+          message: 'Rewarded ad completed',
+        ),
+      );
     } else {
-      await _onPurchaseEvent(PurchaseEvent(
-        productId: productId,
-        status: PurchaseStatus.canceled,
-        message: 'Rewarded ad not completed',
-      ));
+      await _onPurchaseEvent(
+        PurchaseEvent(
+          productId: productId,
+          status: PurchaseStatus.canceled,
+          message: 'Rewarded ad not completed',
+        ),
+      );
     }
   }
 
@@ -230,10 +231,10 @@ class IntegratedStoreService extends ChangeNotifier {
     final d = diff.inDays;
     final h = diff.inHours % 24;
     if (d > 0) {
-      return '${d}天${h}小時';
+      return '$d天$h小時';
     } else {
       final m = diff.inMinutes % 60;
-      return '${h}小時${m}分';
+      return '$h小時$m分';
     }
   }
 
@@ -244,14 +245,27 @@ class IntegratedStoreService extends ChangeNotifier {
       // 更新購買記錄
       final nowLocal = _getCurrentTaipeiTime();
       await _limiter.markPurchased(event.productId, nowLocal);
-      
+
+      // 發放對應權益（例如：store.card_click_perm 啟用永久點擊 1.5x）
+      try {
+        // EntitlementManager 的配置鍵為 'store.*'，若傳入 sku 需補上前綴
+        final grantId = event.productId.startsWith('store.')
+            ? event.productId
+            : 'store.${event.productId}';
+        await _entitlementManager.grant(skuId: grantId);
+      } catch (e) {
+        debugPrint('Entitlement grant failed for ${event.productId}: $e');
+      }
+
       // 通知 UI 更新
       notifyListeners();
-      
+
       // 這裡未來可以加入權益下發邏輯
       debugPrint('Purchase successful: ${event.productId}');
     } else {
-      debugPrint('Purchase event: ${event.status} for ${event.productId} - ${event.message}');
+      debugPrint(
+        'Purchase event: ${event.status} for ${event.productId} - ${event.message}',
+      );
     }
   }
 
@@ -267,6 +281,10 @@ class IntegratedStoreService extends ChangeNotifier {
     for (final productId in storeConfig.keys) {
       await _repository.savePurchaseRecord(productId, const PurchaseRecord());
     }
+    // 一併清除權益持久化資料，避免重置後殘留永久權益或訂單紀錄
+    try {
+      await _entitlementManager.resetPersistedData();
+    } catch (_) {}
     notifyListeners();
   }
 
@@ -314,19 +332,17 @@ class IntegratedStoreService extends ChangeNotifier {
     final days = totalMinutes ~/ (24 * 60);
     final hours = (totalMinutes - days * 24 * 60) ~/ 60;
     final minutes = totalMinutes - days * 24 * 60 - hours * 60;
-    return {
-      'days': days,
-      'hours': hours,
-      'minutes': minutes,
-    };
+    return {'days': days, 'hours': hours, 'minutes': minutes};
   }
 
   /// 釋放資源
   @override
   void dispose() {
     _purchaseSubscription?.cancel();
-    _purchaseService.dispose();
     _purchaseSubscription = null;
+    if (_initialized) {
+      _purchaseService.dispose();
+    }
     _initialized = false;
     _disposed = true;
     super.dispose();
@@ -357,7 +373,7 @@ class IntegratedStoreService extends ChangeNotifier {
     final record = await getPurchaseRecord(itemKey);
     final nowLocal = _getCurrentTaipeiTime();
     final currentDate = _formatDate(nowLocal);
-    
+
     if (record?.daily?.date == currentDate) {
       return record!.daily!.count;
     }
@@ -369,7 +385,7 @@ class IntegratedStoreService extends ChangeNotifier {
     final record = await getPurchaseRecord(itemKey);
     final nowLocal = _getCurrentTaipeiTime();
     final currentYm = _formatYearMonth(nowLocal);
-    
+
     if (record?.monthly?.ym == currentYm) {
       return record!.monthly!.count;
     }
@@ -378,12 +394,12 @@ class IntegratedStoreService extends ChangeNotifier {
 
   String _formatDate(DateTime dateTime) {
     return '${dateTime.year.toString().padLeft(4, '0')}-'
-           '${dateTime.month.toString().padLeft(2, '0')}-'
-           '${dateTime.day.toString().padLeft(2, '0')}';
+        '${dateTime.month.toString().padLeft(2, '0')}-'
+        '${dateTime.day.toString().padLeft(2, '0')}';
   }
 
   String _formatYearMonth(DateTime dateTime) {
     return '${dateTime.year.toString().padLeft(4, '0')}-'
-           '${dateTime.month.toString().padLeft(2, '0')}';
+        '${dateTime.month.toString().padLeft(2, '0')}';
   }
 }

--- a/lib/services/offline_reward_service.dart
+++ b/lib/services/offline_reward_service.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:idle_hippo/models/game_state.dart';
+import 'package:idle_hippo/models/buff_models.dart';
 
 /// 離線收益計算與生命週期管理
 /// - 暫存 lastExitUtcMs 與 idleRateSnapshot 於 GameState.offline
@@ -109,7 +110,7 @@ class OfflineRewardService with WidgetsBindingObserver {
     final elapsedMs = now - last;
     if (elapsedMs <= 0) return; // 負數/無效
 
-    final capSeconds = (gs.offline.capHours * 3600).toDouble();
+    final capSeconds = (_resolveOfflineCapHours(gs) * 3600).toDouble();
     final elapsedSeconds = elapsedMs / 1000.0;
     final effectiveSeconds = elapsedSeconds.clamp(0.0, capSeconds);
 
@@ -153,7 +154,7 @@ class OfflineRewardService with WidgetsBindingObserver {
     if (last <= 0) return Duration.zero;
     final elapsedMs = now - last;
     if (elapsedMs <= 0) return Duration.zero;
-    final capSeconds = (gs.offline.capHours * 3600).toDouble();
+    final capSeconds = (_resolveOfflineCapHours(gs) * 3600).toDouble();
     final eff = (elapsedMs / 1000.0).clamp(0.0, capSeconds);
     return Duration(seconds: eff.floor());
   }
@@ -198,6 +199,23 @@ class OfflineRewardService with WidgetsBindingObserver {
       offline: gs.offline.copyWith(pendingReward: 0.0),
     );
     await _persist(updated);
+  }
+
+  int _resolveOfflineCapHours(GameState state) {
+    final buffs = state.buffs;
+    final baseCap = state.offline.capHours;
+    if (buffs == null) {
+      return baseCap;
+    }
+
+    final nowMs = _nowMs();
+    final buffCap = buffs.getOfflineCapHours(nowMs);
+    final baselineCap = const BuffState().getOfflineCapHours(nowMs);
+    final extra = buffCap - baselineCap;
+    if (extra <= 0) {
+      return baseCap;
+    }
+    return baseCap + extra;
   }
 
   /// Step 11: 玩家點擊「觀看廣告翻倍」按鈕後呼叫，此方法現在只處理狀態更新

--- a/lib/services/purchase_orchestrator.dart
+++ b/lib/services/purchase_orchestrator.dart
@@ -119,7 +119,7 @@ class PurchaseOrchestrator {
           // 僅針對 non-consumable 嘗試權益發放
           if (_isNonConsumable(event.productId)) {
             final entitlement = _entitlementKeyFor(event.productId);
-            await _entitlementManager.grant(entitlement);
+            await _entitlementManager.grant(skuId: entitlement);
             _stateCtr.add(OrchestratorState.success(event.productId));
           }
           // 單輪恢復後即退出恢復模式（若有多筆也逐筆處理）
@@ -135,7 +135,7 @@ class PurchaseOrchestrator {
             );
             if (verify.ok) {
               final entitlement = _entitlementKeyFor(event.productId);
-              await _entitlementManager.grant(entitlement);
+              await _entitlementManager.grant(skuId: entitlement, orderId: 'mock-order');
               _stateCtr.add(OrchestratorState.success(event.productId));
             } else {
               _stateCtr.add(OrchestratorState.error('verify_failed',

--- a/lib/services/purchase_repository.dart
+++ b/lib/services/purchase_repository.dart
@@ -3,12 +3,11 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../models/purchase_models.dart';
 
 /// 購買記錄持久化服務
-/// 
+///
 /// 負責儲存與讀取購買記錄、安裝記錄
 /// 支援跨日/跨月重置邏輯
 class PurchaseRepository {
   static const String _storeKey = 'purchase_store';
-  static const String _installKey = 'purchase_install_date';
 
   PurchaseRepository();
 
@@ -17,19 +16,22 @@ class PurchaseRepository {
     final data = await _loadStoreData();
     final purchases = data['purchases'] as Map<String, dynamic>? ?? {};
     final recordData = purchases[productId] as Map<String, dynamic>?;
-    
+
     if (recordData == null) return null;
-    
+
     return PurchaseRecord.fromJson(recordData);
   }
 
   /// 儲存商品購買記錄
-  Future<void> savePurchaseRecord(String productId, PurchaseRecord record) async {
+  Future<void> savePurchaseRecord(
+    String productId,
+    PurchaseRecord record,
+  ) async {
     final data = await _loadStoreData();
     final purchases = data['purchases'] as Map<String, dynamic>? ?? {};
     purchases[productId] = record.toJson();
     data['purchases'] = purchases;
-    
+
     await _saveStoreData(data);
   }
 
@@ -37,9 +39,9 @@ class PurchaseRepository {
   Future<InstallRecord?> getInstallRecord() async {
     final data = await _loadStoreData();
     final installData = data['install'] as Map<String, dynamic>?;
-    
+
     if (installData == null) return null;
-    
+
     return InstallRecord.fromJson(installData);
   }
 
@@ -47,7 +49,7 @@ class PurchaseRepository {
   Future<void> saveInstallRecord(InstallRecord record) async {
     final data = await _loadStoreData();
     data['install'] = record.toJson();
-    
+
     await _saveStoreData(data);
   }
 
@@ -67,26 +69,23 @@ class PurchaseRepository {
     final data = await _loadStoreData();
     final purchases = data['purchases'] as Map<String, dynamic>? ?? {};
     final currentDate = _formatDate(nowLocal);
-    
+
     bool hasChanges = false;
-    
+
     for (final entry in purchases.entries) {
       final recordData = entry.value as Map<String, dynamic>;
       final dailyData = recordData['daily'] as Map<String, dynamic>?;
-      
+
       if (dailyData != null) {
         final recordDate = dailyData['date'] as String;
         if (recordDate != currentDate) {
           // 跨日重置
-          recordData['daily'] = {
-            'date': currentDate,
-            'count': 0,
-          };
+          recordData['daily'] = {'date': currentDate, 'count': 0};
           hasChanges = true;
         }
       }
     }
-    
+
     if (hasChanges) {
       data['purchases'] = purchases;
       await _saveStoreData(data);
@@ -98,26 +97,23 @@ class PurchaseRepository {
     final data = await _loadStoreData();
     final purchases = data['purchases'] as Map<String, dynamic>? ?? {};
     final currentYm = _formatYearMonth(nowLocal);
-    
+
     bool hasChanges = false;
-    
+
     for (final entry in purchases.entries) {
       final recordData = entry.value as Map<String, dynamic>;
       final monthlyData = recordData['monthly'] as Map<String, dynamic>?;
-      
+
       if (monthlyData != null) {
         final recordYm = monthlyData['ym'] as String;
         if (recordYm != currentYm) {
           // 跨月重置
-          recordData['monthly'] = {
-            'ym': currentYm,
-            'count': 0,
-          };
+          recordData['monthly'] = {'ym': currentYm, 'count': 0};
           hasChanges = true;
         }
       }
     }
-    
+
     if (hasChanges) {
       data['purchases'] = purchases;
       await _saveStoreData(data);
@@ -150,13 +146,13 @@ class PurchaseRepository {
   /// 格式化日期為 YYYY-MM-DD (Asia/Taipei)
   String _formatDate(DateTime dateTime) {
     return '${dateTime.year.toString().padLeft(4, '0')}-'
-           '${dateTime.month.toString().padLeft(2, '0')}-'
-           '${dateTime.day.toString().padLeft(2, '0')}';
+        '${dateTime.month.toString().padLeft(2, '0')}-'
+        '${dateTime.day.toString().padLeft(2, '0')}';
   }
 
   /// 格式化年月為 YYYY-MM (Asia/Taipei)
   String _formatYearMonth(DateTime dateTime) {
     return '${dateTime.year.toString().padLeft(4, '0')}-'
-           '${dateTime.month.toString().padLeft(2, '0')}';
+        '${dateTime.month.toString().padLeft(2, '0')}';
   }
 }

--- a/lib/ui/debug_panel.dart
+++ b/lib/ui/debug_panel.dart
@@ -5,6 +5,7 @@ import '../services/idle_income_service.dart';
 import '../services/pet_service.dart';
 import '../services/gacha_service.dart';
 import '../models/game_state.dart';
+import '../models/buff_models.dart';
 import '../services/tap_service.dart';
 import '../services/daily_mission_service.dart';
 import '../services/checkin_service.dart';
@@ -178,6 +179,13 @@ class _DebugPanelState extends State<DebugPanel> {
                 _buildIdleIncomeStats(),
                 const SizedBox(height: 8),
 
+                // Buffs Section
+                if (widget.gameState?.buffs != null) ...[
+                  _buildSectionTitle('Buffs'),
+                  _buildBuffStats(),
+                  const SizedBox(height: 8),
+                ],
+
                 // Daily Mission Section
                 if (widget.dailyMissionService != null &&
                     widget.gameState != null) ...[
@@ -283,6 +291,36 @@ class _DebugPanelState extends State<DebugPanel> {
           stats['averageIncomePerSec']?.toStringAsFixed(3) ?? '0.0',
         ),
         _buildConfigRow('subscribed', stats['isSubscribed']),
+      ],
+    );
+  }
+
+  Widget _buildBuffStats() {
+    final buffs = widget.gameState!.buffs!;
+    final nowMs = DateTime.now().millisecondsSinceEpoch;
+    TimedBuff? idleBuff;
+    for (final buff in buffs.activeBuffs) {
+      if (buff.type == 'idle_2x' && !buff.isExpired(nowMs)) {
+        idleBuff = buff;
+        break;
+      }
+    }
+
+    final remainingLabel = idleBuff != null
+        ? _formatDurationMs(idleBuff.getRemainingMs(nowMs))
+        : '0s';
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildConfigRow(
+          'idle_2x.remaining',
+          remainingLabel,
+        ),
+        _buildConfigRow(
+          'idle_2x.multiplier',
+          idleBuff?.multiplier ?? '-',
+        ),
       ],
     );
   }
@@ -554,6 +592,21 @@ class _DebugPanelState extends State<DebugPanel> {
         ),
       ],
     );
+  }
+
+  String _formatDurationMs(int ms) {
+    if (ms <= 0) return '0s';
+    final duration = Duration(milliseconds: ms);
+    final hours = duration.inHours;
+    final minutes = duration.inMinutes.remainder(60);
+    final seconds = duration.inSeconds.remainder(60);
+    if (hours > 0) {
+      return '${hours}h ${minutes}m ${seconds}s';
+    }
+    if (minutes > 0) {
+      return '${minutes}m ${seconds}s';
+    }
+    return '${seconds}s';
   }
 
   String _formatTimestamp(int timestamp) {

--- a/lib/ui/main_screen.dart
+++ b/lib/ui/main_screen.dart
@@ -30,6 +30,7 @@ import 'package:idle_hippo/services/gacha_service.dart';
 import 'package:idle_hippo/models/game_state.dart';
 import 'package:idle_hippo/services/config_service.dart';
 import 'package:idle_hippo/services/game_state_service.dart';
+import 'package:idle_hippo/services/equipment_service.dart';
 
 class MainScreen extends StatefulWidget {
   final double memePoints;
@@ -409,10 +410,21 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
     final particleY = characterCenterY + math.sin(angle) * distance;
 
     final particleKey = UniqueKey();
-    final displayValue =
-        (widget.lastTapDisplayValue != null && widget.lastTapDisplayValue! > 0)
-        ? widget.lastTapDisplayValue!
-        : gained;
+    final equipmentService = EquipmentService();
+    final computedGain = equipmentService.computeTapGain(
+      widget.gameState,
+      currentTimeMs: DateTime.now().millisecondsSinceEpoch,
+    );
+    final displayValue = () {
+      final latest = widget.lastTapDisplayValue;
+      if (latest != null && latest > 0) {
+        return latest;
+      }
+      if (computedGain > 0) {
+        return computedGain;
+      }
+      return gained;
+    }();
     final particle = PlusMemeParticle(
       key: particleKey,
       startPosition: Offset(particleX, particleY),

--- a/lib/ui/pages/shop_page.dart
+++ b/lib/ui/pages/shop_page.dart
@@ -238,9 +238,6 @@ class _StoreCard extends StatelessWidget {
     final adsPay = (data['ads_pay'] ?? false) as bool;
 
     final badgeText = _badgeText(i18n, limitType);
-    final int maxCount = (data['purchase_max_count'] is int)
-        ? (data['purchase_max_count'] as int)
-        : 1;
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 6),
@@ -308,11 +305,15 @@ class _StoreCard extends StatelessWidget {
                               animation: IntegratedStoreService(),
                               builder: (context, _) {
                                 return FutureBuilder<PurchaseAvailability>(
-                                  future: IntegratedStoreService().getAvailability(itemKey),
+                                  future: IntegratedStoreService()
+                                      .getAvailability(itemKey),
                                   builder: (context, snapshot) {
-                                    final availability = snapshot.data ?? const PurchaseAvailability(false);
+                                    final availability =
+                                        snapshot.data ??
+                                        const PurchaseAvailability(false);
                                     final bool showBuy = availability.canBuy;
-                                    final bool isDailyPack = itemKey == 'store.pack_daily';
+                                    final bool isDailyPack =
+                                        itemKey == 'store.pack_daily';
                                     final String buyText = i18n.getString(
                                       'store.btn.buy',
                                       defaultValue: 'Buy',
@@ -332,31 +333,57 @@ class _StoreCard extends StatelessWidget {
                                           GestureDetector(
                                             onTap: () async {
                                               try {
-                                                await IntegratedStoreService().buyProductViaIap(itemKey);
+                                                await IntegratedStoreService()
+                                                    .buyProductViaIap(itemKey);
                                                 if (context.mounted) {
-                                                  ScaffoldMessenger.of(context).showSnackBar(
+                                                  ScaffoldMessenger.of(
+                                                    context,
+                                                  ).showSnackBar(
                                                     SnackBar(
-                                                      content: Text(i18n.getString('store.purchase_success', defaultValue: 'Purchase successful!')),
-                                                      backgroundColor: Colors.green,
+                                                      content: Text(
+                                                        i18n.getString(
+                                                          'store.purchase_success',
+                                                          defaultValue:
+                                                              'Purchase successful!',
+                                                        ),
+                                                      ),
+                                                      backgroundColor:
+                                                          Colors.green,
                                                     ),
                                                   );
                                                 }
                                               } catch (e) {
                                                 if (context.mounted) {
-                                                  ScaffoldMessenger.of(context).showSnackBar(
+                                                  ScaffoldMessenger.of(
+                                                    context,
+                                                  ).showSnackBar(
                                                     SnackBar(
-                                                      content: Text(i18n.getString('store.purchase_failed', defaultValue: 'Purchase failed!')),
-                                                      backgroundColor: Colors.red,
+                                                      content: Text(
+                                                        i18n.getString(
+                                                          'store.purchase_failed',
+                                                          defaultValue:
+                                                              'Purchase failed!',
+                                                        ),
+                                                      ),
+                                                      backgroundColor:
+                                                          Colors.red,
                                                     ),
                                                   );
                                                 }
                                               }
                                             },
                                             child: Container(
-                                              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                                              padding:
+                                                  const EdgeInsets.symmetric(
+                                                    horizontal: 12,
+                                                    vertical: 6,
+                                                  ),
                                               decoration: BoxDecoration(
-                                                color: const Color(0xFF00FFD1).withValues(alpha: 0.9),
-                                                borderRadius: BorderRadius.circular(8),
+                                                color: const Color(
+                                                  0xFF00FFD1,
+                                                ).withValues(alpha: 0.9),
+                                                borderRadius:
+                                                    BorderRadius.circular(8),
                                               ),
                                               child: Text(
                                                 buyText,
@@ -374,34 +401,63 @@ class _StoreCard extends StatelessWidget {
                                           GestureDetector(
                                             onTap: () async {
                                               try {
-                                                await IntegratedStoreService().buyProductViaAd(itemKey);
+                                                await IntegratedStoreService()
+                                                    .buyProductViaAd(itemKey);
                                                 if (context.mounted) {
-                                                  ScaffoldMessenger.of(context).showSnackBar(
+                                                  ScaffoldMessenger.of(
+                                                    context,
+                                                  ).showSnackBar(
                                                     SnackBar(
-                                                      content: Text(i18n.getString('store.ad_purchase_success', defaultValue: 'Ad reward received!')),
-                                                      backgroundColor: Colors.green,
+                                                      content: Text(
+                                                        i18n.getString(
+                                                          'store.ad_purchase_success',
+                                                          defaultValue:
+                                                              'Ad reward received!',
+                                                        ),
+                                                      ),
+                                                      backgroundColor:
+                                                          Colors.green,
                                                     ),
                                                   );
                                                 }
                                               } catch (e) {
                                                 if (context.mounted) {
-                                                  ScaffoldMessenger.of(context).showSnackBar(
+                                                  ScaffoldMessenger.of(
+                                                    context,
+                                                  ).showSnackBar(
                                                     SnackBar(
-                                                      content: Text(i18n.getString('store.ad_purchase_failed', defaultValue: 'Ad reward failed!')),
-                                                      backgroundColor: Colors.red,
+                                                      content: Text(
+                                                        i18n.getString(
+                                                          'store.ad_purchase_failed',
+                                                          defaultValue:
+                                                              'Ad reward failed!',
+                                                        ),
+                                                      ),
+                                                      backgroundColor:
+                                                          Colors.red,
                                                     ),
                                                   );
                                                 }
                                               }
                                             },
                                             child: Container(
-                                              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                                              padding:
+                                                  const EdgeInsets.symmetric(
+                                                    horizontal: 12,
+                                                    vertical: 6,
+                                                  ),
                                               decoration: BoxDecoration(
-                                                color: Colors.orange.withValues(alpha: 0.9),
-                                                borderRadius: BorderRadius.circular(8),
+                                                color: Colors.orange.withValues(
+                                                  alpha: 0.9,
+                                                ),
+                                                borderRadius:
+                                                    BorderRadius.circular(8),
                                               ),
                                               child: Text(
-                                                i18n.getString('store.btn.ad_buy', defaultValue: 'Watch Ad'),
+                                                i18n.getString(
+                                                  'store.btn.ad_buy',
+                                                  defaultValue: 'Watch Ad',
+                                                ),
                                                 overflow: TextOverflow.ellipsis,
                                                 style: const TextStyle(
                                                   color: Colors.black,
@@ -425,31 +481,57 @@ class _StoreCard extends StatelessWidget {
                                           GestureDetector(
                                             onTap: () async {
                                               try {
-                                                await IntegratedStoreService().buyProduct(itemKey);
+                                                await IntegratedStoreService()
+                                                    .buyProduct(itemKey);
                                                 if (context.mounted) {
-                                                  ScaffoldMessenger.of(context).showSnackBar(
+                                                  ScaffoldMessenger.of(
+                                                    context,
+                                                  ).showSnackBar(
                                                     SnackBar(
-                                                      content: Text(i18n.getString('store.purchase_success', defaultValue: 'Purchase successful!')),
-                                                      backgroundColor: Colors.green,
+                                                      content: Text(
+                                                        i18n.getString(
+                                                          'store.purchase_success',
+                                                          defaultValue:
+                                                              'Purchase successful!',
+                                                        ),
+                                                      ),
+                                                      backgroundColor:
+                                                          Colors.green,
                                                     ),
                                                   );
                                                 }
                                               } catch (e) {
                                                 if (context.mounted) {
-                                                  ScaffoldMessenger.of(context).showSnackBar(
+                                                  ScaffoldMessenger.of(
+                                                    context,
+                                                  ).showSnackBar(
                                                     SnackBar(
-                                                      content: Text(i18n.getString('store.purchase_failed', defaultValue: 'Purchase failed!')),
-                                                      backgroundColor: Colors.red,
+                                                      content: Text(
+                                                        i18n.getString(
+                                                          'store.purchase_failed',
+                                                          defaultValue:
+                                                              'Purchase failed!',
+                                                        ),
+                                                      ),
+                                                      backgroundColor:
+                                                          Colors.red,
                                                     ),
                                                   );
                                                 }
                                               }
                                             },
                                             child: Container(
-                                              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                                              padding:
+                                                  const EdgeInsets.symmetric(
+                                                    horizontal: 12,
+                                                    vertical: 6,
+                                                  ),
                                               decoration: BoxDecoration(
-                                                color: const Color(0xFF00FFD1).withValues(alpha: 0.9),
-                                                borderRadius: BorderRadius.circular(8),
+                                                color: const Color(
+                                                  0xFF00FFD1,
+                                                ).withValues(alpha: 0.9),
+                                                borderRadius:
+                                                    BorderRadius.circular(8),
                                               ),
                                               child: Text(
                                                 buyText,
@@ -464,14 +546,24 @@ class _StoreCard extends StatelessWidget {
                                           )
                                         else if (!showBuy)
                                           Container(
-                                            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                                            padding: const EdgeInsets.symmetric(
+                                              horizontal: 12,
+                                              vertical: 6,
+                                            ),
                                             decoration: BoxDecoration(
-                                              color: Colors.white.withValues(alpha: 0.08),
-                                              borderRadius: BorderRadius.circular(8),
+                                              color: Colors.white.withValues(
+                                                alpha: 0.08,
+                                              ),
+                                              borderRadius:
+                                                  BorderRadius.circular(8),
                                             ),
                                             child: Text(
                                               availability.reasonKey != null
-                                                  ? i18n.getString(availability.reasonKey!, defaultValue: disabledText)
+                                                  ? i18n.getString(
+                                                      availability.reasonKey!,
+                                                      defaultValue:
+                                                          disabledText,
+                                                    )
                                                   : disabledText,
                                               overflow: TextOverflow.ellipsis,
                                               style: const TextStyle(
@@ -487,34 +579,63 @@ class _StoreCard extends StatelessWidget {
                                           GestureDetector(
                                             onTap: () async {
                                               try {
-                                                await IntegratedStoreService().buyProduct(itemKey);
+                                                await IntegratedStoreService()
+                                                    .buyProduct(itemKey);
                                                 if (context.mounted) {
-                                                  ScaffoldMessenger.of(context).showSnackBar(
+                                                  ScaffoldMessenger.of(
+                                                    context,
+                                                  ).showSnackBar(
                                                     SnackBar(
-                                                      content: Text(i18n.getString('store.ad_purchase_success', defaultValue: 'Ad reward received!')),
-                                                      backgroundColor: Colors.green,
+                                                      content: Text(
+                                                        i18n.getString(
+                                                          'store.ad_purchase_success',
+                                                          defaultValue:
+                                                              'Ad reward received!',
+                                                        ),
+                                                      ),
+                                                      backgroundColor:
+                                                          Colors.green,
                                                     ),
                                                   );
                                                 }
                                               } catch (e) {
                                                 if (context.mounted) {
-                                                  ScaffoldMessenger.of(context).showSnackBar(
+                                                  ScaffoldMessenger.of(
+                                                    context,
+                                                  ).showSnackBar(
                                                     SnackBar(
-                                                      content: Text(i18n.getString('store.ad_purchase_failed', defaultValue: 'Ad reward failed!')),
-                                                      backgroundColor: Colors.red,
+                                                      content: Text(
+                                                        i18n.getString(
+                                                          'store.ad_purchase_failed',
+                                                          defaultValue:
+                                                              'Ad reward failed!',
+                                                        ),
+                                                      ),
+                                                      backgroundColor:
+                                                          Colors.red,
                                                     ),
                                                   );
                                                 }
                                               }
                                             },
                                             child: Container(
-                                              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                                              padding:
+                                                  const EdgeInsets.symmetric(
+                                                    horizontal: 12,
+                                                    vertical: 6,
+                                                  ),
                                               decoration: BoxDecoration(
-                                                color: Colors.orange.withValues(alpha: 0.9),
-                                                borderRadius: BorderRadius.circular(8),
+                                                color: Colors.orange.withValues(
+                                                  alpha: 0.9,
+                                                ),
+                                                borderRadius:
+                                                    BorderRadius.circular(8),
                                               ),
                                               child: Text(
-                                                i18n.getString('store.btn.ad_buy', defaultValue: 'Ad Purchase'),
+                                                i18n.getString(
+                                                  'store.btn.ad_buy',
+                                                  defaultValue: 'Ad Purchase',
+                                                ),
                                                 overflow: TextOverflow.ellipsis,
                                                 style: const TextStyle(
                                                   color: Colors.black,
@@ -526,13 +647,22 @@ class _StoreCard extends StatelessWidget {
                                           )
                                         else if (adsPay)
                                           Container(
-                                            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                                            padding: const EdgeInsets.symmetric(
+                                              horizontal: 12,
+                                              vertical: 6,
+                                            ),
                                             decoration: BoxDecoration(
-                                              color: Colors.white.withValues(alpha: 0.08),
-                                              borderRadius: BorderRadius.circular(8),
+                                              color: Colors.white.withValues(
+                                                alpha: 0.08,
+                                              ),
+                                              borderRadius:
+                                                  BorderRadius.circular(8),
                                             ),
                                             child: Text(
-                                              i18n.getString('store.btn.ad_buy', defaultValue: 'Ad Purchase'),
+                                              i18n.getString(
+                                                'store.btn.ad_buy',
+                                                defaultValue: 'Ad Purchase',
+                                              ),
                                               overflow: TextOverflow.ellipsis,
                                               style: const TextStyle(
                                                 color: Colors.white54,
@@ -544,46 +674,85 @@ class _StoreCard extends StatelessWidget {
                                         // 限制標籤與剩餘次數（first7/first30 額外顯示倒數，使用 i18n 單位）
                                         if (badgeText.isNotEmpty)
                                           FutureBuilder<Map<String, int>?>(
-                                            future: (limitType == 'first7' || limitType == 'first30')
-                                                ? IntegratedStoreService().getFirstPeriodRemaining(itemKey)
+                                            future:
+                                                (limitType == 'first7' ||
+                                                    limitType == 'first30')
+                                                ? IntegratedStoreService()
+                                                      .getFirstPeriodRemaining(
+                                                        itemKey,
+                                                      )
                                                 : Future.value(null),
                                             builder: (context, cdSnap) {
-                                              final baseText = availability.remaining > 0
+                                              final baseText =
+                                                  availability.remaining > 0
                                                   ? '$badgeText (${availability.remaining})'
                                                   : badgeText;
                                               String text = baseText;
-                                              if (cdSnap.connectionState == ConnectionState.done && cdSnap.data != null) {
-                                                final d = cdSnap.data!['days'] ?? 0;
-                                                final h = cdSnap.data!['hours'] ?? 0;
-                                                final m = cdSnap.data!['minutes'] ?? 0;
-                                                final dayUnit = i18n.getString('store.time.day', defaultValue: '天');
-                                                final hourUnit = i18n.getString('store.time.hour', defaultValue: '小時');
-                                                final minuteUnit = i18n.getString('store.time.minute', defaultValue: '分');
+                                              if (cdSnap.connectionState ==
+                                                      ConnectionState.done &&
+                                                  cdSnap.data != null) {
+                                                final d =
+                                                    cdSnap.data!['days'] ?? 0;
+                                                final h =
+                                                    cdSnap.data!['hours'] ?? 0;
+                                                final m =
+                                                    cdSnap.data!['minutes'] ??
+                                                    0;
+                                                final dayUnit = i18n.getString(
+                                                  'store.time.day',
+                                                  defaultValue: '天',
+                                                );
+                                                final hourUnit = i18n.getString(
+                                                  'store.time.hour',
+                                                  defaultValue: '小時',
+                                                );
+                                                final minuteUnit = i18n
+                                                    .getString(
+                                                      'store.time.minute',
+                                                      defaultValue: '分',
+                                                    );
                                                 String timeStr;
                                                 if (d > 0) {
-                                                  timeStr = '$d$dayUnit$h$hourUnit';
+                                                  timeStr =
+                                                      '$d$dayUnit$h$hourUnit';
                                                 } else {
-                                                  timeStr = '$h$hourUnit$m$minuteUnit';
+                                                  timeStr =
+                                                      '$h$hourUnit$m$minuteUnit';
                                                 }
-                                                final cdTpl = i18n.getString('store.badge.countdown', defaultValue: '倒數：{time}');
-                                                final cdText = cdTpl.replaceAll('{time}', timeStr);
+                                                final cdTpl = i18n.getString(
+                                                  'store.badge.countdown',
+                                                  defaultValue: '倒數：{time}',
+                                                );
+                                                final cdText = cdTpl.replaceAll(
+                                                  '{time}',
+                                                  timeStr,
+                                                );
                                                 text = '$baseText · $cdText';
                                               }
                                               return Container(
-                                                padding: const EdgeInsets.symmetric(
-                                                  horizontal: 10,
-                                                  vertical: 4,
-                                                ),
+                                                padding:
+                                                    const EdgeInsets.symmetric(
+                                                      horizontal: 10,
+                                                      vertical: 4,
+                                                    ),
                                                 decoration: BoxDecoration(
-                                                  color: Colors.black.withValues(alpha: 0.2),
+                                                  color: Colors.black
+                                                      .withValues(alpha: 0.2),
                                                   border: Border.all(
-                                                    color: Colors.white.withValues(alpha: 0.15),
+                                                    color: Colors.white
+                                                        .withValues(
+                                                          alpha: 0.15,
+                                                        ),
                                                   ),
-                                                  borderRadius: BorderRadius.circular(999),
+                                                  borderRadius:
+                                                      BorderRadius.circular(
+                                                        999,
+                                                      ),
                                                 ),
                                                 child: Text(
                                                   text,
-                                                  overflow: TextOverflow.ellipsis,
+                                                  overflow:
+                                                      TextOverflow.ellipsis,
                                                   style: const TextStyle(
                                                     color: Colors.white70,
                                                     fontSize: 11,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -489,7 +489,7 @@ packages:
     source: hosted
     version: "0.11.1"
   meta:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: meta
       sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   just_audio: ^0.9.42
   path: ^1.9.0
   uuid: ^4.4.0
+  meta: ^1.16.0
 
 dev_dependencies:
   flutter_test:

--- a/test/daily_tap_service_test.dart
+++ b/test/daily_tap_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:idle_hippo/models/game_state.dart';
+import 'package:idle_hippo/models/buff_models.dart';
 import 'package:idle_hippo/services/daily_tap_service.dart';
 
 void main() {
@@ -29,6 +30,18 @@ void main() {
       final stats = svc.getStats(result.state);
       expect(stats['todayGained'], 1);
       expect(stats['effectiveCap'], 200);
+    });
+
+    test('永久上限加成會放大每日上限', () {
+      final buffedState = state.copyWith(
+        buffs: const BuffState(
+          permanent: PermanentEntitlements(capIncreased: true),
+        ),
+      );
+
+      final ensured = svc.ensureDailyBlock(buffedState);
+      final stats = svc.getStats(ensured);
+      expect(stats['effectiveCap'], 300); // 200 * 1.5
     });
 
     test('上限規則：允許收益應被夾制到剩餘值', () {

--- a/test/equipment_service_test.dart
+++ b/test/equipment_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:idle_hippo/models/game_state.dart';
+import 'package:idle_hippo/models/buff_models.dart';
 import 'package:idle_hippo/services/equipment_service.dart';
 import 'package:idle_hippo/services/game_state_service.dart';
 
@@ -35,6 +36,22 @@ void main() {
       equipment.computeTapGain(state),
       1,
     ); // base=1 from assets/config/game.json
+  });
+
+  test('computeTapGain：永久點擊加成會乘上最終獲得點數', () {
+    final state = GameState.initial(1).copyWith(
+      buffs: const BuffState(
+        permanent: PermanentEntitlements(clickBoost: 1.5),
+      ),
+    );
+
+    expect(
+      equipment.computeTapGain(
+        state,
+        currentTimeMs: DateTime(2024).millisecondsSinceEpoch,
+      ),
+      1.5,
+    );
   });
 
   test('升級成功：扣除成本並提升等級', () {

--- a/test/offline_reward_service_test.dart
+++ b/test/offline_reward_service_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:idle_hippo/models/game_state.dart';
+import 'package:idle_hippo/models/buff_models.dart';
 import 'package:idle_hippo/services/config_service.dart';
 import 'package:idle_hippo/services/offline_reward_service.dart';
 
@@ -111,6 +112,22 @@ void main() {
       await service.simulateAddSeconds(threeHours);
       expect(lastReward, closeTo(twoHours * 2.0, 1e-6));
       expect(lastEffective, Duration(seconds: twoHours));
+    });
+
+    test('永久離線上限加成會延長封頂時間', () async {
+      final tenHours = 10 * 3600;
+      state = state.copyWith(
+        buffs: const BuffState(
+          permanent: PermanentEntitlements(offlineExtended: true),
+        ),
+      );
+
+      await service.simulateAddSeconds(tenHours);
+
+      final expectedCapHours = state.offline.capHours + 6; // +6 小時永久加成
+      final expectedCapSeconds = expectedCapHours * 3600;
+      expect(lastReward, closeTo(expectedCapSeconds * idlePerSec, 1e-6));
+      expect(lastEffective, Duration(seconds: expectedCapSeconds));
     });
   });
 

--- a/test/secure_save_service_test.dart
+++ b/test/secure_save_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:idle_hippo/models/game_state.dart';
+import 'package:idle_hippo/models/buff_models.dart';
 
 void main() {
   group('GameState 模型測試', () {
@@ -19,12 +20,16 @@ void main() {
         memePoints: 123.0,
         equipments: {'youtube': 2, 'idle_chip': 0},
         lastTs: 1724000000000,
+        buffs: const BuffState(),
       );
 
       final json = originalState.toJson();
       final deserializedState = GameState.fromJson(json);
 
-      expect(deserializedState, equals(originalState));
+      expect(
+        deserializedState.toMap(),
+        equals(originalState.toMap()),
+      );
     });
 
     test('應能正確驗證', () {
@@ -94,6 +99,7 @@ void main() {
         memePoints: 999.0,
         equipments: {'sword': 5, 'shield': 3, 'potion': 0},
         lastTs: DateTime.now().toUtc().millisecondsSinceEpoch,
+        buffs: const BuffState(),
       );
 
       // Multiple serialization cycles
@@ -103,7 +109,10 @@ void main() {
         currentState = GameState.fromJson(json);
       }
 
-      expect(currentState, equals(originalState));
+      expect(
+        currentState.toMap(),
+        equals(originalState.toMap()),
+      );
       expect(currentState.validate(), true);
     });
 
@@ -113,13 +122,17 @@ void main() {
         memePoints: 0.0,
         equipments: {},
         lastTs: 1,
+        buffs: const BuffState(),
       );
 
       expect(edgeState.validate(), true);
 
       final json = edgeState.toJson();
       final deserializedState = GameState.fromJson(json);
-      expect(deserializedState, equals(edgeState));
+      expect(
+        deserializedState.toMap(),
+        equals(edgeState.toMap()),
+      );
     });
   });
 }

--- a/test/step09_idle_equipment_test.dart
+++ b/test/step09_idle_equipment_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:idle_hippo/models/game_state.dart';
+import 'package:idle_hippo/models/buff_models.dart';
 import 'package:idle_hippo/services/config_service.dart';
 import 'package:idle_hippo/services/equipment_service.dart';
 import 'package:idle_hippo/services/idle_income_service.dart';
@@ -220,6 +221,25 @@ void main() {
       idleIncomeService.updateGameState(state);
       final idlePerSec = idleIncomeService.currentIdlePerSec;
       expect(idlePerSec, greaterThan(0.2));
+    });
+
+    test('永久 Idle 加成會乘上放置收益', () {
+      final baseState = GameState.initial(1);
+      idleIncomeService.updateGameState(baseState);
+      final basePerSec = idleIncomeService.currentIdlePerSec;
+
+      final buffedState = baseState.copyWith(
+        buffs: const BuffState(
+          permanent: PermanentEntitlements(idleBoost: 1.2),
+        ),
+      );
+      idleIncomeService.updateGameState(buffedState);
+      final buffedPerSec = idleIncomeService.currentIdlePerSec;
+
+      expect(buffedPerSec, closeTo(basePerSec * 1.2, 1e-6));
+
+      // reset to base to avoid干擾其他測試
+      idleIncomeService.updateGameState(baseState);
     });
 
     test('放置裝備收益隨時間累積', () {

--- a/test/step26-2/integrated_store_service_test.dart
+++ b/test/step26-2/integrated_store_service_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:idle_hippo/models/purchase_models.dart';
 import 'package:idle_hippo/services/config_service.dart';
 import 'package:idle_hippo/services/integrated_store_service.dart';
 // SecureSaveService 未在整合商城測試中使用，避免引入平台相依介面

--- a/test/step26-2/purchase_limiter_test.dart
+++ b/test/step26-2/purchase_limiter_test.dart
@@ -24,7 +24,7 @@ void main() {
     setUp(() {
       // 以記憶體實作初始化 SharedPreferences，避免 plugin 造成測試等待
       SharedPreferences.setMockInitialValues({});
-      final Map<String, dynamic> _storeConfig = {
+      final Map<String, dynamic> storeConfig = {
         'unlimited_item': {
           'purchase_limit_type': 'unlimited',
           'purchase_max_count': 999,
@@ -47,7 +47,7 @@ void main() {
           'purchase_max_count': 2,
         },
       };
-      mockConfig = MockConfigService(_storeConfig);
+      mockConfig = MockConfigService(storeConfig);
       repository = PurchaseRepository();
       limiter = PurchaseLimiterImpl(mockConfig, repository);
     });
@@ -193,9 +193,11 @@ void main() {
         final installDate = DateTime(2025, 8, 1);
         final testDate = DateTime(2025, 8, 5); // 第 5 天
 
-        // 設定安裝記錄
+        // 設定安裝記錄（使用 installDate）
+        final installDateStr =
+            '${installDate.year.toString().padLeft(4, '0')}-${installDate.month.toString().padLeft(2, '0')}-${installDate.day.toString().padLeft(2, '0')}';
         await repository.saveInstallRecord(
-          InstallRecord(firstOpenDate: '2025-08-01'),
+          InstallRecord(firstOpenDate: installDateStr),
         );
 
         final availability = await limiter.availability(
@@ -210,9 +212,11 @@ void main() {
         final installDate = DateTime(2025, 8, 1);
         final testDate = DateTime(2025, 8, 10); // 第 10 天，超過 7 天
 
-        // 設定安裝記錄
+        // 設定安裝記錄（使用 installDate）
+        final installDateStr =
+            '${installDate.year.toString().padLeft(4, '0')}-${installDate.month.toString().padLeft(2, '0')}-${installDate.day.toString().padLeft(2, '0')}';
         await repository.saveInstallRecord(
-          InstallRecord(firstOpenDate: '2025-08-01'),
+          InstallRecord(firstOpenDate: installDateStr),
         );
 
         final availability = await limiter.availability(
@@ -231,9 +235,11 @@ void main() {
         final installDate = DateTime(2025, 8, 1);
         final testDate = DateTime(2025, 8, 25); // 第 25 天
 
-        // 設定安裝記錄
+        // 設定安裝記錄（使用 installDate）
+        final installDateStr =
+            '${installDate.year.toString().padLeft(4, '0')}-${installDate.month.toString().padLeft(2, '0')}-${installDate.day.toString().padLeft(2, '0')}';
         await repository.saveInstallRecord(
-          InstallRecord(firstOpenDate: '2025-08-01'),
+          InstallRecord(firstOpenDate: installDateStr),
         );
 
         final availability = await limiter.availability(
@@ -248,9 +254,11 @@ void main() {
         final installDate = DateTime(2025, 8, 1);
         final testDate = DateTime(2025, 9, 5); // 超過 30 天
 
-        // 設定安裝記錄
+        // 設定安裝記錄（使用 installDate）
+        final installDateStr =
+            '${installDate.year.toString().padLeft(4, '0')}-${installDate.month.toString().padLeft(2, '0')}-${installDate.day.toString().padLeft(2, '0')}';
         await repository.saveInstallRecord(
-          InstallRecord(firstOpenDate: '2025-08-01'),
+          InstallRecord(firstOpenDate: installDateStr),
         );
 
         final availability = await limiter.availability(
@@ -268,9 +276,11 @@ void main() {
         final installDate = DateTime(2025, 8, 1);
         final testDate = DateTime(2025, 8, 3); // 第 3 天
 
-        // 設定安裝記錄
+        // 設定安裝記錄（使用 installDate）
+        final installDateStr =
+            '${installDate.year.toString().padLeft(4, '0')}-${installDate.month.toString().padLeft(2, '0')}-${installDate.day.toString().padLeft(2, '0')}';
         await repository.saveInstallRecord(
-          InstallRecord(firstOpenDate: '2025-08-01'),
+          InstallRecord(firstOpenDate: installDateStr),
         );
 
         // 購買到上限

--- a/test/step27/entitlement_manager_test.dart
+++ b/test/step27/entitlement_manager_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:idle_hippo/services/entitlement_manager.dart';
+
+void main() {
+  group('EntitlementManager 冪等處理測試', () {
+    late MockEntitlementManager entitlementManager;
+
+    setUp(() {
+      entitlementManager = MockEntitlementManager();
+    });
+
+    group('驗收需求 1: non-consumable 冪等', () {
+      test('連續兩次 grant 同一 non-consumable 商品，只會處理一次', () async {
+        const skuId = 'card_click_perm';
+        const orderId = 'A';
+
+        // 第一次發放
+        await entitlementManager.grant(skuId: skuId, orderId: orderId);
+        
+        // 驗證訂單已記錄且商品已發放
+        expect(entitlementManager.hasGrantedOrder(orderId), isTrue);
+        expect(entitlementManager.granted.contains(skuId), isTrue);
+        expect(entitlementManager.granted.length, equals(1));
+
+        // 第二次發放（應該被跳過）
+        await entitlementManager.grant(skuId: skuId, orderId: orderId);
+        
+        // 驗證仍然只有一次記錄，沒有重複觸發副作用
+        expect(entitlementManager.hasGrantedOrder(orderId), isTrue);
+        expect(entitlementManager.granted.length, equals(1));
+      });
+    });
+
+    group('驗收需求 2: consumable 冪等', () {
+      test('連續兩次 grant 同一 consumable 訂單，資源僅被加一次', () async {
+        const skuId = 'card_click_2x_30m';
+        const orderId = 'B';
+
+        // 第一次發放
+        await entitlementManager.grant(skuId: skuId, orderId: orderId);
+        
+        // 驗證訂單已記錄且資源已發放
+        expect(entitlementManager.hasGrantedOrder(orderId), isTrue);
+        expect(entitlementManager.granted.contains(skuId), isTrue);
+        final firstGrantCount = entitlementManager.granted.length;
+
+        // 第二次發放（應該被跳過）
+        await entitlementManager.grant(skuId: skuId, orderId: orderId);
+        
+        // 驗證資源僅被加一次，orders.B 僅一筆
+        expect(entitlementManager.hasGrantedOrder(orderId), isTrue);
+        expect(entitlementManager.granted.length, equals(firstGrantCount));
+      });
+
+      test('不同 orderId 的相同 consumable 商品，都應該被處理', () async {
+        const skuId = 'ticket_pet_single';
+        const orderId1 = 'C1';
+        const orderId2 = 'C2';
+
+        // 第一次發放
+        await entitlementManager.grant(skuId: skuId, orderId: orderId1);
+        
+        // 第二次發放（不同 orderId，應該被處理）
+        await entitlementManager.grant(skuId: skuId, orderId: orderId2);
+        
+        // 驗證兩個訂單都已記錄
+        expect(entitlementManager.hasGrantedOrder(orderId1), isTrue);
+        expect(entitlementManager.hasGrantedOrder(orderId2), isTrue);
+        // 同一商品可以發放多次（consumable）
+        expect(entitlementManager.granted.where((item) => item == skuId).length, equals(2));
+      });
+    });
+
+    group('驗收需求 3: 缺 orderId（恢復 non-consumable）', () {
+      test('non-consumable 商品無 orderId 時仍能設置 entitlement 並具備冪等', () async {
+        const skuId = 'card_idle_perm';
+
+        // 第一次發放（無 orderId）
+        await entitlementManager.grant(skuId: skuId);
+        
+        // 驗證商品已發放
+        expect(entitlementManager.granted.contains(skuId), isTrue);
+        final firstGrantCount = entitlementManager.granted.length;
+
+        // 第二次發放（重複呼叫不再觸發）
+        await entitlementManager.grant(skuId: skuId);
+        
+        // 驗證具備冪等性（重複呼叫不再觸發）
+        expect(entitlementManager.granted.length, equals(firstGrantCount));
+      });
+
+      test('consumable 商品無 orderId 時每次都會處理', () async {
+        const skuId = 'card_idle_2x_1h';
+
+        // 第一次發放（無 orderId）
+        await entitlementManager.grant(skuId: skuId);
+        
+        // 驗證商品已發放
+        expect(entitlementManager.granted.contains(skuId), isTrue);
+        final firstGrantCount = entitlementManager.granted.length;
+
+        // 第二次發放（無 orderId，應該再次處理）
+        await entitlementManager.grant(skuId: skuId);
+        
+        // 驗證狀態再次變化（consumable 可重複發放）
+        expect(entitlementManager.granted.length, equals(firstGrantCount + 1));
+      });
+    });
+
+    group('邊界情況測試', () {
+      test('空字串 orderId 處理', () async {
+        const skuId = 'test_sku';
+        const orderId = '';
+
+        await entitlementManager.grant(skuId: skuId, orderId: orderId);
+        expect(entitlementManager.hasGrantedOrder(orderId), isTrue);
+      });
+
+      test('相同 skuId 不同 orderId 處理', () async {
+        const skuId = 'test_sku';
+        const orderId1 = 'order1';
+        const orderId2 = 'order2';
+
+        await entitlementManager.grant(skuId: skuId, orderId: orderId1);
+        await entitlementManager.grant(skuId: skuId, orderId: orderId2);
+
+        expect(entitlementManager.hasGrantedOrder(orderId1), isTrue);
+        expect(entitlementManager.hasGrantedOrder(orderId2), isTrue);
+        expect(entitlementManager.granted.length, equals(2));
+      });
+    });
+  });
+}

--- a/test/step27/sku_mapper_test.dart
+++ b/test/step27/sku_mapper_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import '../../lib/services/sku_mapper.dart';
+import 'package:idle_hippo/services/sku_mapper.dart';
 
 void main() {
   group('SkuMapper 測試', () {
@@ -8,7 +8,7 @@ void main() {
     setUpAll(() async {
       // 設定測試環境
       TestWidgetsFlutterBinding.ensureInitialized();
-      
+
       skuMapper = SkuMapper.instance;
       await skuMapper.init();
     });
@@ -17,10 +17,10 @@ void main() {
       test('應該成功將 store.card_click_perm 轉換為 card_click_perm', () {
         // Given
         const String storeId = 'store.card_click_perm';
-        
+
         // When
         final String skuId = skuMapper.getSkuId(storeId);
-        
+
         // Then
         expect(skuId, equals('card_click_perm'));
       });
@@ -28,10 +28,10 @@ void main() {
       test('應該成功將 store.card_idle_perm 轉換為 card_idle_perm', () {
         // Given
         const String storeId = 'store.card_idle_perm';
-        
+
         // When
         final String skuId = skuMapper.getSkuId(storeId);
-        
+
         // Then
         expect(skuId, equals('card_idle_perm'));
       });
@@ -39,10 +39,10 @@ void main() {
       test('應該成功將 store.pack_monthly 轉換為 pack_monthly', () {
         // Given
         const String storeId = 'store.pack_monthly';
-        
+
         // When
         final String skuId = skuMapper.getSkuId(storeId);
-        
+
         // Then
         expect(skuId, equals('pack_monthly'));
       });
@@ -52,7 +52,7 @@ void main() {
       test('不存在的 storeId 應該拋出 SkuMappingNotFound 例外', () {
         // Given
         const String invalidStoreId = 'store.not_exists';
-        
+
         // When & Then
         expect(
           () => skuMapper.getSkuId(invalidStoreId),
@@ -63,7 +63,7 @@ void main() {
       test('SkuMappingNotFound 例外應該包含正確的 storeId', () {
         // Given
         const String invalidStoreId = 'store.invalid_item';
-        
+
         // When & Then
         try {
           skuMapper.getSkuId(invalidStoreId);
@@ -78,7 +78,7 @@ void main() {
       test('沒有 store. 前綴的 ID 應該拋出 SkuMappingNotFound 例外', () {
         // Given
         const String invalidStoreId = 'card_click_perm';
-        
+
         // When & Then
         expect(
           () => skuMapper.getSkuId(invalidStoreId),
@@ -89,7 +89,7 @@ void main() {
       test('空字串應該拋出 SkuMappingNotFound 例外', () {
         // Given
         const String emptyStoreId = '';
-        
+
         // When & Then
         expect(
           () => skuMapper.getSkuId(emptyStoreId),
@@ -102,7 +102,7 @@ void main() {
       test('所有 tabs 中的 storeId 都應該能成功轉換', () {
         // When
         final bool isValid = skuMapper.validateAllTabsStoreIds();
-        
+
         // Then
         expect(isValid, isTrue);
       });
@@ -110,13 +110,13 @@ void main() {
       test('getAllStoreIds 應該回傳所有有效的 storeId', () {
         // When
         final List<String> storeIds = skuMapper.getAllStoreIds();
-        
+
         // Then
         expect(storeIds, contains('store.card_click_perm'));
         expect(storeIds, contains('store.card_idle_perm'));
         expect(storeIds, contains('store.pack_monthly'));
         expect(storeIds.length, greaterThan(0));
-        
+
         // 驗證所有 storeId 都以 'store.' 開頭
         for (final storeId in storeIds) {
           expect(storeId, startsWith('store.'));
@@ -126,11 +126,11 @@ void main() {
       test('所有 getAllStoreIds 回傳的 storeId 都應該能成功轉換', () {
         // Given
         final List<String> allStoreIds = skuMapper.getAllStoreIds();
-        
+
         // When & Then
         for (final String storeId in allStoreIds) {
           expect(() => skuMapper.getSkuId(storeId), returnsNormally);
-          
+
           // 驗證轉換結果格式正確
           final String skuId = skuMapper.getSkuId(storeId);
           expect(skuId, isNot(contains('store.')));
@@ -144,9 +144,12 @@ void main() {
         // Given & When
         await skuMapper.init();
         await skuMapper.init(); // 重複初始化
-        
+
         // Then
-        expect(() => skuMapper.getSkuId('store.card_click_perm'), returnsNormally);
+        expect(
+          () => skuMapper.getSkuId('store.card_click_perm'),
+          returnsNormally,
+        );
       });
     });
   });

--- a/test/step27/store_effects_test.dart
+++ b/test/step27/store_effects_test.dart
@@ -1,0 +1,437 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:idle_hippo/models/buff_models.dart';
+import 'package:idle_hippo/models/game_state.dart';
+import 'package:idle_hippo/services/entitlement_manager.dart';
+import 'package:idle_hippo/services/game_state_service.dart';
+
+/// Mock GameStateService 用於測試
+class MockGameStateService implements GameStateService {
+  @override
+  ValueNotifier<GameState> gameState = ValueNotifier<GameState>(
+    GameState.initial(1),
+  );
+
+  GameState _currentState = GameState.initial(1);
+
+  @override
+  GameState get currentState => _currentState;
+
+  @override
+  Future<void> initialize() async {
+    // No-op for tests
+  }
+
+  @override
+  Future<void> initializeForTest(GameState initialState) async {
+    _currentState = initialState;
+    gameState.value = initialState;
+  }
+
+  @override
+  Future<void> updateGameState(
+    GameState newState, {
+    bool forceReplace = false,
+    bool throwOnError = false,
+  }) async {
+    _currentState = newState;
+    gameState.value = newState;
+  }
+}
+
+void main() {
+  // 初始化 Flutter 測試綁定，確保 rootBundle 可載入資產
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+  });
+
+  group('商品效益完整測試', () {
+    late EntitlementManagerImpl entitlementManager;
+    late MockGameStateService gameStateService;
+
+    setUp(() async {
+      gameStateService = MockGameStateService();
+      entitlementManager = EntitlementManagerImpl(
+        gameStateService: gameStateService,
+      );
+
+      // 初始化測試環境
+      await entitlementManager.init();
+    });
+
+    group('永久效果商品測試', () {
+      test('點擊加成永久卡片', () async {
+        const skuId = 'store.card_click_perm';
+        const orderId = 'test_order_001';
+
+        // 發放權益
+        await entitlementManager.grant(skuId: skuId, orderId: orderId);
+
+        // 驗證權益已發放
+        expect(entitlementManager.hasEntitlement(skuId), isTrue);
+        expect(entitlementManager.hasGrantedOrder(orderId), isTrue);
+
+        // 驗證遊戲狀態更新
+        final currentState = gameStateService.currentState;
+        expect(currentState.buffs, isNotNull);
+        expect(currentState.buffs!.permanent.clickBoost, equals(1.5));
+
+        // 驗證點擊倍數計算
+        final currentTimeMs = DateTime.now().millisecondsSinceEpoch;
+        final clickMultiplier = currentState.buffs!.getClickMultiplier(
+          currentTimeMs,
+        );
+        expect(clickMultiplier, equals(1.5)); // +50% 加成
+      });
+
+      test('Idle 加成永久卡片', () async {
+        const skuId = 'store.card_idle_perm';
+        const orderId = 'test_order_002';
+
+        await entitlementManager.grant(skuId: skuId, orderId: orderId);
+
+        expect(entitlementManager.hasEntitlement(skuId), isTrue);
+
+        final currentState = gameStateService.currentState;
+        expect(currentState.buffs!.permanent.idleBoost, equals(1.2));
+
+        final currentTimeMs = DateTime.now().millisecondsSinceEpoch;
+        final idleMultiplier = currentState.buffs!.getIdleMultiplier(
+          currentTimeMs,
+        );
+        expect(idleMultiplier, equals(1.2)); // +20% 加成
+      });
+
+      test('離線時間永久擴展', () async {
+        const skuId = 'store.card_offline_perm_6h';
+
+        await entitlementManager.grant(skuId: skuId);
+
+        final currentState = gameStateService.currentState;
+        expect(currentState.buffs!.permanent.offlineExtended, isTrue);
+
+        final currentTimeMs = DateTime.now().millisecondsSinceEpoch;
+        final offlineCapHours = currentState.buffs!.getOfflineCapHours(
+          currentTimeMs,
+        );
+        expect(offlineCapHours, equals(12)); // 基礎 6 小時 + 永久 6 小時
+      });
+
+      test('每日上限永久提升', () async {
+        const skuId = 'store.card_cap_perm';
+
+        await entitlementManager.grant(skuId: skuId);
+
+        final currentState = gameStateService.currentState;
+        expect(currentState.buffs!.permanent.capIncreased, isTrue);
+
+        final dailyCapMultiplier = currentState.buffs!.getDailyCapMultiplier();
+        expect(dailyCapMultiplier, equals(1.5)); // +50% 加成
+      });
+    });
+
+    group('限時效果商品測試', () {
+      test('點擊 2x 限時卡片', () async {
+        const skuId = 'store.card_click_2x_30m';
+        const orderId = 'test_order_003';
+
+        await entitlementManager.grant(skuId: skuId, orderId: orderId);
+
+        final currentState = gameStateService.currentState;
+        expect(currentState.buffs!.activeBuffs.length, equals(1));
+
+        final buff = currentState.buffs!.activeBuffs.first;
+        expect(buff.type, equals('click_2x'));
+        expect(buff.multiplier, equals(2.0));
+
+        // 驗證 buff 未過期
+        final currentTimeMs = DateTime.now().millisecondsSinceEpoch;
+        expect(buff.isExpired(currentTimeMs), isFalse);
+
+        // 驗證倍數計算
+        final clickMultiplier = currentState.buffs!.getClickMultiplier(
+          currentTimeMs,
+        );
+        expect(clickMultiplier, equals(2.0));
+      });
+
+      test('Idle 2x 限時卡片', () async {
+        const skuId = 'store.card_idle_2x_1h';
+
+        await entitlementManager.grant(skuId: skuId);
+
+        final currentState = gameStateService.currentState;
+        final buff = currentState.buffs!.activeBuffs.first;
+        expect(buff.type, equals('idle_2x'));
+        expect(buff.multiplier, equals(2.0));
+
+        final currentTimeMs = DateTime.now().millisecondsSinceEpoch;
+        final idleMultiplier = currentState.buffs!.getIdleMultiplier(
+          currentTimeMs,
+        );
+        expect(idleMultiplier, equals(2.0));
+      });
+
+      test('限時 buff 延長機制', () async {
+        const skuId = 'store.card_click_2x_30m';
+
+        // 第一次發放
+        await entitlementManager.grant(skuId: skuId, orderId: 'order_001');
+
+        final firstState = gameStateService.currentState;
+        final firstBuff = firstState.buffs!.activeBuffs.first;
+        final firstExpiresAt = firstBuff.expiresAtMs;
+
+        // 等待一小段時間
+        await Future.delayed(const Duration(milliseconds: 10));
+
+        // 第二次發放（應該延長時間）
+        await entitlementManager.grant(skuId: skuId, orderId: 'order_002');
+
+        final secondState = gameStateService.currentState;
+        expect(secondState.buffs!.activeBuffs.length, equals(1)); // 仍然只有一個 buff
+
+        final secondBuff = secondState.buffs!.activeBuffs.first;
+        expect(secondBuff.expiresAtMs, greaterThan(firstExpiresAt)); // 時間延長了
+      });
+    });
+
+    group('即時效果商品測試', () {
+      test('寵物抽獎券', () async {
+        const skuId = 'store.ticket_pet_single';
+        const initialTickets = 5;
+
+        // 設定初始狀態
+        final initialState = gameStateService.currentState.copyWith(
+          petTickets: initialTickets,
+        );
+        await gameStateService.updateGameState(initialState);
+
+        await entitlementManager.grant(skuId: skuId);
+
+        final currentState = gameStateService.currentState;
+        expect(currentState.petTickets, equals(initialTickets + 1));
+      });
+    });
+
+    group('組合包商品測試', () {
+      test('每日禮包', () async {
+        const skuId = 'store.pack_daily';
+        const initialPoints = 100.0;
+        const initialTickets = 1;
+
+        final initialState = gameStateService.currentState.copyWith(
+          memePoints: initialPoints,
+          petTickets: initialTickets,
+        );
+        await gameStateService.updateGameState(initialState);
+
+        final grantTime = DateTime.now().millisecondsSinceEpoch;
+        await entitlementManager.grant(skuId: skuId);
+
+        final currentState = gameStateService.currentState;
+        expect(currentState.memePoints, equals(initialPoints + 300));
+        expect(currentState.petTickets, equals(initialTickets + 2));
+        expect(currentState.buffs!.activeBuffs.length, equals(1));
+
+        final buff = currentState.buffs!.activeBuffs.first;
+        expect(buff.type, equals('idle_2x'));
+        expect(buff.multiplier, equals(2.0));
+        final expectedDurationMs = 30 * 60 * 1000;
+        final actualDuration = buff.expiresAtMs - grantTime;
+        expect(
+          actualDuration,
+          inInclusiveRange(expectedDurationMs, expectedDurationMs + 5000),
+        );
+      });
+
+      test('每月禮包', () async {
+        const skuId = 'store.pack_monthly';
+        const initialPoints = 500.0;
+        const initialTickets = 3;
+
+        final initialState = gameStateService.currentState.copyWith(
+          memePoints: initialPoints,
+          petTickets: initialTickets,
+        );
+        await gameStateService.updateGameState(initialState);
+
+        final grantTime = DateTime.now().millisecondsSinceEpoch;
+        await entitlementManager.grant(skuId: skuId);
+
+        final currentState = gameStateService.currentState;
+        expect(currentState.memePoints, equals(initialPoints + 3000));
+        expect(currentState.petTickets, equals(initialTickets + 22));
+        expect(currentState.buffs!.activeBuffs.length, equals(1));
+
+        final buff = currentState.buffs!.activeBuffs.first;
+        expect(buff.type, equals('idle_2x'));
+        expect(buff.multiplier, equals(2.0));
+        final expectedDurationMs = 24 * 60 * 60 * 1000;
+        final actualDuration = buff.expiresAtMs - grantTime;
+        expect(
+          actualDuration,
+          inInclusiveRange(expectedDurationMs, expectedDurationMs + 10000),
+        );
+      });
+
+      test('新手 7 日禮包', () async {
+        const skuId = 'store.pack_7n_starter';
+        const initialPoints = 200.0;
+        const initialTickets = 0;
+
+        final initialState = gameStateService.currentState.copyWith(
+          memePoints: initialPoints,
+          petTickets: initialTickets,
+        );
+        await gameStateService.updateGameState(initialState);
+
+        final grantTime = DateTime.now().millisecondsSinceEpoch;
+        await entitlementManager.grant(skuId: skuId);
+
+        final currentState = gameStateService.currentState;
+        expect(currentState.memePoints, equals(initialPoints + 1000));
+        expect(currentState.petTickets, equals(initialTickets + 11));
+        expect(currentState.buffs!.activeBuffs.length, equals(1));
+
+        final buff = currentState.buffs!.activeBuffs.first;
+        expect(buff.type, equals('idle_2x'));
+        expect(buff.multiplier, equals(2.0));
+        final expectedDurationMs = 24 * 60 * 60 * 1000;
+        final actualDuration = buff.expiresAtMs - grantTime;
+        expect(
+          actualDuration,
+          inInclusiveRange(expectedDurationMs, expectedDurationMs + 10000),
+        );
+      });
+
+      test('新手 30 日禮包', () async {
+        const skuId = 'store.pack_30n_starter';
+        const initialPoints = 400.0;
+        const initialTickets = 5;
+
+        final initialState = gameStateService.currentState.copyWith(
+          memePoints: initialPoints,
+          petTickets: initialTickets,
+        );
+        await gameStateService.updateGameState(initialState);
+
+        final grantTime = DateTime.now().millisecondsSinceEpoch;
+        await entitlementManager.grant(skuId: skuId);
+
+        final currentState = gameStateService.currentState;
+        expect(currentState.memePoints, equals(initialPoints + 5000));
+        expect(currentState.petTickets, equals(initialTickets + 33));
+        expect(currentState.buffs!.activeBuffs.length, equals(1));
+
+        final buff = currentState.buffs!.activeBuffs.first;
+        expect(buff.type, equals('idle_2x'));
+        expect(buff.multiplier, equals(2.0));
+        final expectedDurationMs = 120 * 60 * 60 * 1000;
+        final actualDuration = buff.expiresAtMs - grantTime;
+        expect(
+          actualDuration,
+          inInclusiveRange(expectedDurationMs, expectedDurationMs + 10000),
+        );
+      });
+    });
+
+    group('冪等性和錯誤處理', () {
+      test('重複發放永久商品', () async {
+        const skuId = 'store.card_click_perm';
+        const orderId = 'test_order_duplicate';
+
+        // 第一次發放
+        await entitlementManager.grant(skuId: skuId, orderId: orderId);
+        expect(entitlementManager.hasEntitlement(skuId), isTrue);
+
+        final firstState = gameStateService.currentState;
+        final firstClickBoost = firstState.buffs!.permanent.clickBoost;
+
+        // 第二次發放（相同 orderId，應該被跳過）
+        await entitlementManager.grant(skuId: skuId, orderId: orderId);
+
+        final secondState = gameStateService.currentState;
+        expect(
+          secondState.buffs!.permanent.clickBoost,
+          equals(firstClickBoost),
+        );
+      });
+
+      test('不存在的商品 SKU', () async {
+        const skuId = 'store.non_existent_item';
+
+        await entitlementManager.grant(skuId: skuId);
+
+        // 應該不會拋出異常，但也不會有任何效果
+        expect(entitlementManager.hasEntitlement(skuId), isFalse);
+      });
+
+      test('清理過期 buff', () async {
+        // 創建一個已過期的 buff
+        final expiredBuff = TimedBuff(
+          type: 'click_2x',
+          multiplier: 2.0,
+          expiresAtMs: DateTime.now().millisecondsSinceEpoch - 1000, // 1秒前過期
+        );
+
+        final stateWithExpiredBuff = gameStateService.currentState.copyWith(
+          buffs: BuffState(activeBuffs: [expiredBuff]),
+        );
+        await gameStateService.updateGameState(stateWithExpiredBuff);
+
+        // 清理過期 buff
+        await entitlementManager.cleanupExpiredBuffs();
+
+        final cleanedState = gameStateService.currentState;
+        expect(cleanedState.buffs!.activeBuffs.isEmpty, isTrue);
+      });
+    });
+
+    group('複合效果測試', () {
+      test('永久 + 限時效果疊加', () async {
+        // 發放永久點擊加成
+        await entitlementManager.grant(skuId: 'store.card_click_perm');
+
+        // 發放限時點擊加成
+        await entitlementManager.grant(skuId: 'store.card_click_2x_30m');
+
+        final currentState = gameStateService.currentState;
+        final currentTimeMs = DateTime.now().millisecondsSinceEpoch;
+
+        // 驗證效果疊加：永久 1.5x * 限時 2x = 3x
+        final totalMultiplier = currentState.buffs!.getClickMultiplier(
+          currentTimeMs,
+        );
+        expect(totalMultiplier, equals(3.0));
+      });
+
+      test('多個限時效果疊加', () async {
+        // 發放點擊限時加成
+        await entitlementManager.grant(
+          skuId: 'store.card_click_2x_30m',
+          orderId: 'order_1',
+        );
+
+        // 發放 Idle 限時加成
+        await entitlementManager.grant(
+          skuId: 'store.card_idle_2x_1h',
+          orderId: 'order_2',
+        );
+
+        final currentState = gameStateService.currentState;
+        expect(currentState.buffs!.activeBuffs.length, equals(2));
+
+        final currentTimeMs = DateTime.now().millisecondsSinceEpoch;
+        expect(
+          currentState.buffs!.getClickMultiplier(currentTimeMs),
+          equals(2.0),
+        );
+        expect(
+          currentState.buffs!.getIdleMultiplier(currentTimeMs),
+          equals(2.0),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
# 階段 27-3｜權益發放 & 冪等

## 目標

集中管理「發獎」與「冪等處理」。

* non-consumable：設永久旗標
* consumable：加資源 & 記錄交易
* 任一交易 **同一 `orderId`/`purchaseToken` 只處理一次**
* 實現目前 store.json 中所有商品的購買後效益

### 規格

* 新增 `EntitlementManager`（純前端、本地持久化）
  * `Future<void> grant({required String skuId, String? orderId})`
  * `bool hasGrantedOrder(String orderId)`
  * non-consumable 永久旗標：`entitlement_$skuId = true`
  * consumable：**加資源**（呼叫你現有的加值 API，如：加票、加 buff 時間），再記錄 `orderId → granted`
  * 若 `orderId` 為 `null`（Mock 恢復、或非 Android 平台），以 `skuId` 為冪等鍵（僅 non-consumable 可接受）
* 交易日誌（本地存檔）結構（示意）
  ```json
  {
    "orders": {
      "GPA.XXXX": { "skuId": "card_click_2x_30m", "grantedAt": 1737xxxx }
    },
    "entitlements": {
      "card_click_perm": true,
      "card_idle_perm": true
    }
  }
  ```
* 實現目前 store.json 中所有商品的購買後效益
  * 下面每個商品效益或是數字要參數化，且互相獨立
* `store.card_click_perm`：購買成功時，每次點擊或獲得迷因點數額外 +50%
* `store.card_idle_perm`：購買成功時，idlePerSec 累積額外 +20%
* `store.card_click_2x_30m`：購買成功時，點擊收益乘以 2，並開始 30 分鐘倒數（重複購買延長 30 分鐘）
* `store.card_idle_2x_1h`：購買成功時，idlePerSec 乘以 2，並開始 1 小時倒數（重複購買延長 1 小時）
* `store.card_offline_perm_6h`：購買成功時，離線獎勵永久 +6 小時（由 6h → 12h）
* `store.card_offline_once_6h`：購買成功時，離線獎勵暫時 +6 小時，並開始 24 小時倒數（重複購買延長 24 小時）
* `store.card_cap_perm`：購買成功時，每日點擊上限永久 +50%（200 → 300）
* `store.ticket_pet_single`：購買成功時，寵物抽獎券 +1
* `store.ticket_pet_10plus1`：購買成功時，寵物抽獎券 +11
* `store.pack_daily`：立即獲得迷因點數 +300、寵物抽獎券 +2，並啟動 idle 2x（30 分鐘，重複購買延長 30 分鐘）
* `store.pack_monthly`：立即獲得迷因點數 +3000、寵物抽獎券 +22，並啟動 idle 2x（24 小時，重複購買延長 24 小時）
* `store.pack_7n_starter`：立即獲得迷因點數 +1000、寵物抽獎券 +11，並啟動 idle 2x（24 小時）
* `store.pack_30n_starter`：立即獲得迷因點數 +5000、寵物抽獎券 +33，並啟動 idle 2x（120 小時）


## 驗收實例化需求

1. **non-consumable 冪等**
   * Given：連續兩次 `grant(skuId='store.card_click_perm', orderId='A')`
   * Then：只會寫入一次 `entitlements.card_click_perm=true`（不重複觸發副作用）
2. **consumable 冪等**
   * Given：`grant(skuId='store.card_click_2x_30m', orderId='B')` 呼叫兩次
   * Then：資源僅被加一次，`orders.B` 僅一筆
3. **缺 orderId（恢復 non-consumable）**
   * Given：`grant(skuId='store.card_idle_perm', orderId=null)`
   * Then：仍能設置 entitlement 並具備冪等（重複呼叫不再觸發）
4. **store.card_click_perm：點擊加成 50%**
   * Given：原本點擊一次獲得 10 點迷因
   * When：`grant(skuId='store.card_click_perm')`
   * Then：點擊一次應獲得 `10 * 1.5 = 15 點`
5. **store.card_idle_perm：Idle 加成 20%**
   * Given：原本 idle 每秒 +5 點迷因
   * When：`grant(skuId='store.card_idle_perm')`
   * Then：idle 每秒應獲得 `5 * 1.2 = 6 點`
6. **store.card_click_2x_30m：點擊加倍限時 30 分鐘**
   * Given：原本點擊一次獲得 10 點迷因
   * When：`grant(skuId='store.card_click_2x_30m')`
   * Then：點擊一次應獲得 `10 * 2 = 20 點`，並建立一個 30 分鐘的倒數計時
   * When：再次購買
   * Then：倒數時間延長為 60 分鐘
7. **store.card_idle_2x_1h：Idle 加倍限時 1 小時**
   * Given：原本 idle 每秒 +5 點迷因
   * When：`grant(skuId='store.card_idle_2x_1h')`
   * Then：idle 每秒應獲得 `5 * 2 = 10 點`，並建立一個 1 小時的倒數計時
   * When：再次購買
   * Then：倒數時間延長為 2 小時
8. **store.card_offline_perm_6h：離線獎勵永久 +6 小時**
   * Given：原本離線可領取時間上限 = 6 小時
   * When：`grant(skuId='store.card_offline_perm_6h')`
   * Then：離線時間上限應為 `12 小時`
9. **store.card_offline_once_6h：離線獎勵暫時 +6 小時（24h 倒數）**
   * Given：原本離線時間上限 = 6 小時
   * When：`grant(skuId='store.card_offline_once_6h')`
   * Then：離線時間上限應為 `12 小時`，並建立一個 24 小時的倒數計時
   * When：再次購買
   * Then：倒數時間延長為 48 小時
10. **store.card_cap_perm：每日上限永久 +50%**
    * Given：原本每日上限 = 200 點
   * When：`grant(skuId='store.card_cap_perm')`
    * Then：每日上限應為 `200 * 1.5 = 300 點`
11. **store.ticket_pet_single：寵物抽獎券 +1**
    * Given：原本抽獎券數量 = 0
   * When：`grant(skuId='store.ticket_pet_single')`
    * Then：抽獎券數量 = 1
12. **store.ticket_pet_10plus1：寵物抽獎券 +11**
    * Given：原本抽獎券數量 = 0
   * When：`grant(skuId='store.ticket_pet_10plus1')`
    * Then：抽獎券數量 = 11
13. **store.pack_daily：每日禮包**
    * When：`grant(skuId='store.pack_daily')`
    * Then：
      * 迷因點數立即增加 300
      * 抽獎券數量 +2
      * idle 每秒累積翻倍（2x），並建立 30 分鐘倒數
    * When：再次購買
    * Then：倒數時間延長為 60 分鐘
14. **store.pack_monthly：每月禮包**
    * When：`grant(skuId='store.pack_monthly')`
    * Then：
      * 迷因點數立即增加 3000
      * 抽獎券數量 +22
      * idle 每秒累積翻倍（2x），並建立 24 小時倒數
    * When：再次購買
    * Then：倒數時間延長為 48 小時
15. **store.pack_7n_starter：新手 7 日禮包**
    * When：`grant(skuId='store.pack_7n_starter')`
    * Then：
      * 迷因點數立即增加 1000
      * 抽獎券數量 +11
      * idle 每秒累積翻倍（2x），並建立 24 小時倒數
16. **store.pack_30n_starter：新手 30 日禮包**
    * When：`grant(skuId='store.pack_30n_starter')`
    * Then：
      * 迷因點數立即增加 5000
      * 抽獎券數量 +33
      * idle 每秒累積翻倍（2x），並建立 120 小時倒數
